### PR TITLE
Events Pagination fix

### DIFF
--- a/resources/js/components/Pagination.vue
+++ b/resources/js/components/Pagination.vue
@@ -1,89 +1,87 @@
 <template>
-
-        <nav class="codeweek-pagination" role="navigation" aria-label="pagination">
-                <ul>
-                        <li>
-                                <a class="back"
-                                   @click.prevent="changePage(pagination.current_page - 1)"
-                                   :disabled="pagination.current_page <= 1">
-                                        {{$t('pagination.previous')}}
-                                </a>
-                        </li>
-                        <li v-for="page in pages">
-                                <a v-if="pagination.current_page != page"
-                                   class="page"
-                                   @click.prevent="changePage(page)">
-                                        {{ page }}
-                                </a>
-                                <a v-else
-                                   class="page current">
-                                        {{ page }}
-                                </a>
-                        </li>
-                        <li>
-                                <a class="next"
-                                   @click.prevent="changePage(pagination.current_page + 1)"
-                                   :disabled="pagination.current_page >= pagination.last_page">
-                                        {{$t('pagination.next')}}
-                                </a>
-                        </li>
-                </ul>
-        </nav>
-
+  <nav class="codeweek-pagination" role="navigation" aria-label="pagination">
+    <ul>
+      <li>
+        <a
+          class="back"
+          @click.prevent="changePage(pagination.current_page - 1)"
+          :disabled="pagination.current_page <= 1"
+        >
+          {{ $t('pagination.previous') }}
+        </a>
+      </li>
+      <li v-for="page in pages">
+        <a
+          v-if="pagination.current_page != page"
+          class="page"
+          @click.prevent="changePage(page)"
+        >
+          {{ page }}
+        </a>
+        <a v-else class="page current">
+          {{ page }}
+        </a>
+      </li>
+      <li>
+        <a
+          class="next"
+          @click.prevent="changePage(pagination.current_page + 1)"
+          :disabled="pagination.current_page >= pagination.last_page"
+        >
+          {{ $t('pagination.next') }}
+        </a>
+      </li>
+    </ul>
+  </nav>
 </template>
 
 <style>
-        .pagination {
-                margin-top: 40px;
-        }
+.pagination {
+  margin-top: 40px;
+}
 </style>
 
 <script>
-    export default {
-        props: ['pagination', 'offset'],
+export default {
+  props: ['pagination', 'offset'],
 
-        methods: {
-            isCurrentPage(page) {
-                return this.pagination.current_page === page;
-            },
+  methods: {
+    isCurrentPage(page) {
+      return this.pagination.current_page === page;
+    },
 
-            changePage(page) {
-                if (page === 0 || (page > this.pagination.last_page)){
-                        return;
-                }
-
-                if (page > this.pagination.last_page) {
-                    page = this.pagination.last_page;
-                }
-
-                this.pagination.current_page = page;
-                this.$dispatch('paginate');
-            }
-        },
-
-        computed: {
-            pages() {
-                let pages = [];
-
-                let from = this.pagination.current_page - Math.floor(this.offset / 2);
-
-                if (from < 1) {
-                    from = 1;
-                }
-
-                let to = from + this.offset - 1;
-
-                if (to > this.pagination.last_page) {
-                    to = this.pagination.last_page;
-                }
-
-                while (from <= to) {
-                    pages.push(from);
-                    from++;
-                }
-
-                return pages;
-            }
-        }
+    changePage(page) {
+      if (page < 1 || page > this.pagination.last_page) {
+        return;
+      }
+      this.pagination.current_page = page;
+      this.$emit('paginate', page); // Emit the event with the new page number
     }
+  },
+
+  computed: {
+    pages() {
+      let pages = [];
+
+      let from = this.pagination.current_page - Math.floor(this.offset / 2);
+
+      if (from < 1) {
+        from = 1;
+      }
+
+      let to = from + this.offset - 1;
+
+      if (to > this.pagination.last_page) {
+        to = this.pagination.last_page;
+      }
+
+      while (from <= to) {
+        pages.push(from);
+        from++;
+      }
+
+      return pages;
+    }
+  }
+};
 </script>


### PR DESCRIPTION
This pull request addresses an issue in Pagination.vue flagged by Paula, where pagination buttons were not functioning as expected. The original code used an outdated event emission method (this.$dispatch('paginate')), which has been updated to the correct Vue.js method (this.$emit('paginate', page)).

**Changes Made:**

- Replaced this.$dispatch('paginate') with this.$emit('paginate', page) in the changePage method.
- Enhanced changePage logic to handle edge cases where the page number is out of bounds.
- Refactored the code for better readability and formatting.

**Impact:**

- Pagination buttons now emit the correct events, enabling the parent component to handle page changes properly.
- Improved user experience during pagination.

**Testing:**

- Manually tested to confirm correct event emission and parent component response.
- Verified that the pagination component renders and functions as expected.