### PR TITLE
Enable Council Presidency content management in Nova

### DIFF
--- a/app/Livewire/PartnerContentComponent.php
+++ b/app/Livewire/PartnerContentComponent.php
@@ -591,6 +591,36 @@ class PartnerContentComponent extends Component
         return collect(self::$defaultPartnersRaw);
     }
 
+    private function getCouncilMembers()
+    {
+        $fromDb = Partner::active()
+            ->ordered()
+            ->whereJsonContains('categories', 'Council Presidency')
+            ->get();
+
+        if ($fromDb->isNotEmpty()) {
+            return $fromDb->map(function (Partner $member) {
+                $obj = $member->toPartnerObject();
+                $obj->title = $member->title ?: 'Council President';
+                $obj->image = $member->main_img_url ?: $member->logo_url;
+
+                return $obj;
+            });
+        }
+
+        return collect([
+            (object) [
+                'name' => 'Annie Bergh – Sweden',
+                'title' => 'Council President',
+                'description' => 'Building bridges between classrooms and code
+                        Annie Bergh began her educational journey in 1991 as a preschool teacher and later taught students aged 6 to 13. But since 2014, she’s taken on a broader mission: supporting all 85 schools in Malmö municipality as a driving force behind internationalisation, coding, and robotics. Annie is the proud caretaker of 17 NAO robots—yes, actual humanoid robots—which teachers across Malmö can borrow to bring coding and AI to life in their classrooms. Through hands-on workshops and energetic TeachMeets, she inspires educators from preschool to upper secondary to integrate technology into their teaching in meaningful and creative ways. 
+                        Until recently, Annie also led the regional First Lego League (FLL) initiative for eight years, helping young minds explore science and innovation through teamwork and robotics. While she no longer teaches in a classroom, she’s still very much an educator—just one with a few more robots and a lot more cables.
+                        My motto in the presidency is: Innovate, educate, collaborate: Together, I know that we can build a brighter, more collaborative future through the power of code.',
+                'image' => 'images/council/AnnieBergh.jpg',
+            ],
+        ]);
+    }
+
     /**
      * Return default partners as array of arrays (for seeding into DB). Call after getAllPartners() or ensure defaults are loaded.
      */
@@ -605,22 +635,9 @@ class PartnerContentComponent extends Component
     public function render()
     {
         if ($this->filter === 'Council Presidency') {
-            // Council Presidency content
-            $councilContent = collect([
-                (object)[
-                    'name' => 'Annie Bergh – Sweden',
-                    'title' => 'Council President',
-                    'description' => 'Building bridges between classrooms and code
-                        Annie Bergh began her educational journey in 1991 as a preschool teacher and later taught students aged 6 to 13. But since 2014, she’s taken on a broader mission: supporting all 85 schools in Malmö municipality as a driving force behind internationalisation, coding, and robotics. Annie is the proud caretaker of 17 NAO robots—yes, actual humanoid robots—which teachers across Malmö can borrow to bring coding and AI to life in their classrooms. Through hands-on workshops and energetic TeachMeets, she inspires educators from preschool to upper secondary to integrate technology into their teaching in meaningful and creative ways. 
-                        Until recently, Annie also led the regional First Lego League (FLL) initiative for eight years, helping young minds explore science and innovation through teamwork and robotics. While she no longer teaches in a classroom, she’s still very much an educator—just one with a few more robots and a lot more cables.
-                        My motto in the presidency is: Innovate, educate, collaborate: Together, I know that we can build a brighter, more collaborative future through the power of code.',
-                    'image' => 'images/council/AnnieBergh.jpg',
-                ],
-            ]);
-
             // Render the Council Presidency content view
             return view('livewire.council-content-component', [
-                'councilMembers' => $councilContent
+                'councilMembers' => $this->getCouncilMembers(),
             ]);
         }
 

--- a/app/Nova/Partner.php
+++ b/app/Nova/Partner.php
@@ -45,6 +45,10 @@ class Partner extends Resource
                 ->nullable()
                 ->help('Display name. Optional for sponsor logos (e.g. EU Code Week Supporters).'),
 
+            Text::make('Title', 'title')
+                ->nullable()
+                ->help('Used in the Council Presidency tab (e.g. "Council President").'),
+
             Text::make('Logo URL', 'logo_url')
                 ->rules('required')
                 ->help('Path from site root, e.g. images/partners/logo.png (no leading slash), or full URL.'),
@@ -53,8 +57,9 @@ class Partner extends Resource
                 ->options([
                     'Partners' => 'Partners',
                     'Sponsor' => 'EU Code Week Supporters (Sponsor)',
+                    'Council Presidency' => 'Council Presidency',
                 ])
-                ->help('Partners = "Partners" tab; Sponsor = "EU Code Week Supporters" tab.')
+                ->help('Partners = "Partners" tab; Sponsor = "EU Code Week Supporters" tab; Council Presidency = "Council Presidency" tab.')
                 ->resolveUsing(function ($value) {
                     $arr = is_array($value) ? $value : (array) json_decode($value ?? '[]', true);
                     return $arr[0] ?? null;
@@ -74,7 +79,7 @@ class Partner extends Resource
 
             Text::make('Main image URL', 'main_img_url')
                 ->nullable()
-                ->help('Larger image path (optional).'),
+                ->help('Larger image path (optional). Used as profile image for Council Presidency.'),
 
             Number::make('Position', 'position')
                 ->min(0)

--- a/app/Partner.php
+++ b/app/Partner.php
@@ -8,6 +8,7 @@ class Partner extends Model
 {
     protected $fillable = [
         'name',
+        'title',
         'logo_url',
         'categories',
         'description',
@@ -41,6 +42,7 @@ class Partner extends Model
         $o = new \stdClass;
         $o->id = $this->id;
         $o->name = $this->name;
+        $o->title = $this->title;
         $o->logo_url = $this->logo_url;
         $o->categories = $this->categories ?? [];
         $o->description = $this->description;

--- a/database/migrations/2026_04_29_120000_add_title_to_partners_table.php
+++ b/database/migrations/2026_04_29_120000_add_title_to_partners_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('partners', function (Blueprint $table) {
+            $table->string('title')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('partners', function (Blueprint $table) {
+            $table->dropColumn('title');
+        });
+    }
+};

--- a/resources/views/livewire/council-content-component.blade.php
+++ b/resources/views/livewire/council-content-component.blade.php
@@ -15,7 +15,7 @@
 
                     <img
                         src="{{ $member->image }}"
-                        alt="Portrait of Stamatis Papadakis, EU Code Week Council President"
+                        alt="Portrait of {{ $member->name }}"
                         class="object-cover h-full max-h-[396px] w-full mt-6 md:hidden block rounded-[12px]"
                     />
 
@@ -59,7 +59,7 @@
                 <aside class="flex justify-center items-center max-md:max-w-full" aria-label="Profile image">
                     <img
                         src="{{ $member->image }}"
-                        alt="Portrait of Stamatis Papadakis, EU Code Week Council President"
+                        alt="Portrait of {{ $member->name }}"
                         class="object-contain md:object-cover w-full max-w-[643px] h-full max-h-[646px] max-md:hidden block rounded-[12px]"
                     />
                 </aside>


### PR DESCRIPTION
## Summary
- move Council Presidency data loading on `/partners` from hardcoded content to DB-backed entries in `partners`
- add `title` support (migration + model + Nova field) and allow selecting `Council Presidency` as a partner category
- keep current Annie profile as fallback and improve council profile image alt text

## Test plan
- [x] run `php artisan migrate --force`
- [x] verify `app/Livewire/PartnerContentComponent.php` loads Council Presidency entries via DB when present
- [x] verify Nova `Partners & Sponsors` supports category `Council Presidency` and field `Title`
- [ ] create/update a Council Presidency entry in Nova and confirm it renders on `https://codeweek.eu/partners`

Made with [Cursor](https://cursor.com)