### PR TITLE
fix(support): create missing support_approvals table on migrate

### DIFF
--- a/database/migrations/2026_05_19_120000_add_gmail_fields_to_support_approvals_table.php
+++ b/database/migrations/2026_05_19_120000_add_gmail_fields_to_support_approvals_table.php
@@ -7,17 +7,61 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
+        if (!Schema::hasTable('support_approvals')) {
+            Schema::create('support_approvals', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('support_case_id')->constrained('support_cases')->cascadeOnDelete();
+
+                $table->string('requested_action')->index();
+                $table->json('payload_json')->nullable();
+                $table->string('risk_level')->index();
+                $table->string('status')->index();
+
+                $table->string('approved_by')->nullable()->index();
+                $table->timestamp('approved_at')->nullable()->index();
+                $table->text('rejected_reason')->nullable();
+
+                $table->string('correlation_id')->nullable()->index();
+                $table->string('gmail_thread_id')->nullable()->index();
+                $table->string('gmail_message_id')->nullable()->index();
+                $table->string('notify_email')->nullable()->index();
+
+                $table->timestamps();
+            });
+
+            return;
+        }
+
         Schema::table('support_approvals', function (Blueprint $table) {
-            $table->string('gmail_thread_id')->nullable()->index()->after('correlation_id');
-            $table->string('gmail_message_id')->nullable()->index()->after('gmail_thread_id');
-            $table->string('notify_email')->nullable()->index()->after('gmail_message_id');
+            if (!Schema::hasColumn('support_approvals', 'gmail_thread_id')) {
+                $table->string('gmail_thread_id')->nullable()->index()->after('correlation_id');
+            }
+            if (!Schema::hasColumn('support_approvals', 'gmail_message_id')) {
+                $table->string('gmail_message_id')->nullable()->index()->after('gmail_thread_id');
+            }
+            if (!Schema::hasColumn('support_approvals', 'notify_email')) {
+                $table->string('notify_email')->nullable()->index()->after('gmail_message_id');
+            }
         });
     }
 
     public function down(): void
     {
+        if (!Schema::hasTable('support_approvals')) {
+            return;
+        }
+
         Schema::table('support_approvals', function (Blueprint $table) {
-            $table->dropColumn(['gmail_thread_id', 'gmail_message_id', 'notify_email']);
+            $columns = array_filter([
+                Schema::hasColumn('support_approvals', 'gmail_thread_id') ? 'gmail_thread_id' : null,
+                Schema::hasColumn('support_approvals', 'gmail_message_id') ? 'gmail_message_id' : null,
+                Schema::hasColumn('support_approvals', 'notify_email') ? 'notify_email' : null,
+            ]);
+
+            if ($columns !== []) {
+                $table->dropColumn($columns);
+            }
         });
     }
 };

--- a/database/migrations/2026_05_19_120100_ensure_support_case_actions_and_messages_tables.php
+++ b/database/migrations/2026_05_19_120100_ensure_support_case_actions_and_messages_tables.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('support_case_actions')) {
+            Schema::create('support_case_actions', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('support_case_id')->constrained('support_cases')->cascadeOnDelete();
+
+                $table->string('action_name')->index();
+                $table->string('action_type')->index();
+
+                $table->json('input_json')->nullable();
+                $table->json('output_json')->nullable();
+
+                $table->boolean('succeeded')->default(false)->index();
+                $table->boolean('requires_approval')->default(false)->index();
+                $table->string('approved_by')->nullable()->index();
+                $table->string('executed_by')->index();
+                $table->text('error_message')->nullable();
+
+                $table->string('correlation_id')->nullable()->index();
+
+                $table->timestamps();
+            });
+        }
+
+        if (!Schema::hasTable('support_case_messages')) {
+            Schema::create('support_case_messages', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('support_case_id')->constrained('support_cases')->cascadeOnDelete();
+
+                $table->string('message_type')->index();
+                $table->string('recipient_email')->nullable()->index();
+                $table->string('subject')->nullable();
+                $table->longText('body');
+                $table->string('delivery_status')->nullable()->index();
+                $table->timestamp('sent_at')->nullable()->index();
+
+                $table->string('correlation_id')->nullable()->index();
+
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('support_case_messages');
+        Schema::dropIfExists('support_case_actions');
+    }
+};


### PR DESCRIPTION
Handle prod drift where support_cases exists but support_approvals was never created, and ensure actions/messages tables exist before pipeline runs.