### PR TITLE
Release: Gmail poll every 1 minute

### DIFF
--- a/config/support_gmail.php
+++ b/config/support_gmail.php
@@ -3,6 +3,9 @@
 return [
     'enabled' => env('SUPPORT_GMAIL_ENABLED', false),
 
+    // How often support:gmail:poll runs (minutes). 1 is fine for low-volume support mailboxes.
+    'poll_interval_minutes' => max(1, (int) env('SUPPORT_GMAIL_POLL_INTERVAL_MINUTES', 1)),
+
     // In a load-balanced setup, use a distributed lock so only one node polls at a time.
     'lock' => [
         'name' => env('SUPPORT_GMAIL_LOCK_NAME', 'support:gmail:poll'),

--- a/docs/support-copilot-allowed-actions.md
+++ b/docs/support-copilot-allowed-actions.md
@@ -88,6 +88,7 @@ Configured in `config/support_gmail.php` → `allowed_write_actions`.
 | Variable | Typical prod | Effect |
 |----------|--------------|--------|
 | `SUPPORT_GMAIL_ENABLED` | `true` | Turns on polling |
+| `SUPPORT_GMAIL_POLL_INTERVAL_MINUTES` | `1` | Scheduler frequency (1–5 typical; increase if Gmail rate limits) |
 | `SUPPORT_GMAIL_DRY_RUN` | `true` | Pipeline sends summaries; writes need **APPROVE** |
 | `SUPPORT_GMAIL_NOTIFY_EMAIL` | `codeweek@matrixinternet.ie` | Dry-run summary recipient |
 | `SUPPORT_GMAIL_ALLOWED_DOMAINS` | `matrixinternet.ie,codeweek.eu` | Ingest + approve senders |

--- a/docs/support-copilot-stakeholder-guide.md
+++ b/docs/support-copilot-stakeholder-guide.md
@@ -9,7 +9,7 @@
 CodeWeek has an automated **support assistant** that:
 
 - Watches a dedicated support inbox
-- Picks up qualifying emails automatically (about every 5 minutes)
+- Picks up qualifying emails automatically (about every minute by default)
 - Runs basic checks on the user account mentioned in the email
 - Sends a **summary email** to **codeweek@matrixinternet.ie** so the team can review before any change is made
 
@@ -144,7 +144,7 @@ Reported by: Rachele (EU CodeWeek coordination)
 | `cw25-x6LtQ` | Extra context for manual verification (V1 may not auto-use the code yet) |
 | Work email sender | Required for ingest and for any later **APPROVE** reply |
 
-**What the team receives (~5 minutes later)**
+**What the team receives (~1 minute later)**
 
 An email to **codeweek@matrixinternet.ie** similar to:
 
@@ -325,7 +325,7 @@ Please update the profile name fields. Email address must stay the same.
 
 | When | What happens |
 |------|----------------|
-| **Within ~5 minutes** | The system reads the inbox and creates a support case |
+| **Within ~1 minute** | The system reads the inbox and creates a support case |
 | **Shortly after** | A summary is emailed to **codeweek@matrixinternet.ie** |
 | **Subject of summary** | `[CW-SUPPORT #123] Support copilot - dry run review` |
 | **Sender** | Code Week Bot (automated) |
@@ -362,7 +362,7 @@ Read the summary email carefully.
 
    (`YES` or `PROCEED` also work.)
 3. Send from **`@matrixinternet.ie`** or **`@codeweek.eu`**
-4. Wait up to ~5 minutes for the system to process your reply
+4. Wait up to ~1 minute for the system to process your reply
 5. You will receive a **follow-up email** in the same thread:
    - **`action completed`** — change was applied
    - **`action failed`** — change was not applied (see errors in the email; check Nova)
@@ -431,7 +431,7 @@ BODY:    User email: someone@example.com
          Problem: ...
          Request: ...
 
-WAIT:    ~5 min → summary at codeweek@matrixinternet.ie
+WAIT:    ~1 min → summary at codeweek@matrixinternet.ie
 
 APPROVE: Only if summary asks — reply with first line: APPROVE
 ```

--- a/routes/console.php
+++ b/routes/console.php
@@ -40,6 +40,13 @@ Schedule::command('app:export-search-data-to-json')->dailyAt('2:00');
 Schedule::command('events:generate-recurring')->dailyAt('01:00');
 
 // Support Gmail copilot: ingest tickets by subject (codeweek-support), run dry-run, email for APPROVE.
-Schedule::command('support:gmail:poll --max=10')
-    ->everyFiveMinutes()
+$supportGmailPoll = Schedule::command('support:gmail:poll --max=10')
     ->when(fn () => (bool) config('support_gmail.enabled'));
+$supportPollMinutes = (int) config('support_gmail.poll_interval_minutes', 1);
+if ($supportPollMinutes <= 1) {
+    $supportGmailPoll->everyMinute();
+} elseif ($supportPollMinutes === 5) {
+    $supportGmailPoll->everyFiveMinutes();
+} else {
+    $supportGmailPoll->cron('*/'.$supportPollMinutes.' * * * *');
+}


### PR DESCRIPTION
## Summary
Poll support Gmail every 1 minute (configurable via `SUPPORT_GMAIL_POLL_INTERVAL_MINUTES`).

## Test plan
- [ ] Deploy master
- [ ] Optional Forge: `SUPPORT_GMAIL_POLL_INTERVAL_MINUTES=1` (default after deploy)


Made with [Cursor](https://cursor.com)