### PR TITLE
fix(support): accept APPROVED in approval replies

### DIFF
--- a/app/Services/Support/SupportApprovalEmailService.php
+++ b/app/Services/Support/SupportApprovalEmailService.php
@@ -195,16 +195,22 @@ class SupportApprovalEmailService
 
     public function isApprovalReply(string $body): bool
     {
-        $keywords = config('support_gmail.approval_keywords', ['approve', 'yes', 'proceed']);
-        $firstLine = strtolower(trim(Str::before(str_replace("\r\n", "\n", $body), "\n")));
+        $keywords = config('support_gmail.approval_keywords', ['approve', 'approved', 'yes', 'proceed']);
+        $lines = explode("\n", str_replace("\r\n", "\n", $body));
 
-        foreach ($keywords as $keyword) {
-            $keyword = strtolower(trim((string) $keyword));
-            if ($keyword === '') {
+        foreach (array_slice($lines, 0, 8) as $line) {
+            $line = strtolower(trim($line));
+            if ($line === '') {
                 continue;
             }
-            if ($firstLine === $keyword || str_starts_with($firstLine, $keyword.' ')) {
-                return true;
+            foreach ($keywords as $keyword) {
+                $keyword = strtolower(trim((string) $keyword));
+                if ($keyword === '') {
+                    continue;
+                }
+                if ($line === $keyword || str_starts_with($line, $keyword.' ')) {
+                    return true;
+                }
             }
         }
 

--- a/config/support_gmail.php
+++ b/config/support_gmail.php
@@ -62,8 +62,8 @@ return [
     // Default recipient for support:gmail:test and dry-run summaries when requester unknown.
     'notify_email' => env('SUPPORT_GMAIL_NOTIFY_EMAIL', 'codeweek@matrixinternet.ie'),
 
-    // First line of a reply must match one of these (case-insensitive) to approve.
-    'approval_keywords' => ['approve', 'yes', 'proceed'],
+    // First non-empty line of a reply must match one of these (case-insensitive) to approve.
+    'approval_keywords' => ['approve', 'approved', 'yes', 'proceed'],
 
     // Subject prefix for approval threads: "[CW-SUPPORT #123] ..."
     'approval_subject_prefix' => '[CW-SUPPORT',

--- a/docs/support-copilot-stakeholder-guide.md
+++ b/docs/support-copilot-stakeholder-guide.md
@@ -360,7 +360,7 @@ Read the summary email carefully.
    APPROVE
    ```
 
-   (`YES` or `PROCEED` also work.)
+   (`APPROVED`, `YES`, or `PROCEED` also work. Must be on its own line near the top of the reply.)
 3. Send from **`@matrixinternet.ie`** or **`@codeweek.eu`**
 4. Wait up to ~1 minute for the system to process your reply
 5. You will receive a **follow-up email** in the same thread:

--- a/tests/Unit/Support/SupportApprovalEmailServiceTest.php
+++ b/tests/Unit/Support/SupportApprovalEmailServiceTest.php
@@ -9,11 +9,13 @@ final class SupportApprovalEmailServiceTest extends TestCase
 {
     public function test_detects_approval_reply_keywords(): void
     {
-        config()->set('support_gmail.approval_keywords', ['approve', 'yes', 'proceed']);
+        config()->set('support_gmail.approval_keywords', ['approve', 'approved', 'yes', 'proceed']);
 
         $svc = app(SupportApprovalEmailService::class);
 
         $this->assertTrue($svc->isApprovalReply("APPROVE\n\nSome quoted text"));
+        $this->assertTrue($svc->isApprovalReply("approved"));
+        $this->assertTrue($svc->isApprovalReply("\n\napproved\n\nOn Tue wrote:"));
         $this->assertTrue($svc->isApprovalReply("yes"));
         $this->assertFalse($svc->isApprovalReply("maybe approve later"));
     }


### PR DESCRIPTION
Fixes approval when users write approved instead of APPROVE.

Made with [Cursor](https://cursor.com)