### PR TITLE
fix(support): stop bot email ingest loop

### DIFF
--- a/app/Services/Support/Gmail/GmailIngestService.php
+++ b/app/Services/Support/Gmail/GmailIngestService.php
@@ -21,6 +21,7 @@ class GmailIngestService
         private readonly SupportActionLogger $logger,
         private readonly SupportSenderAllowlist $allowlist,
         private readonly SupportApprovalEmailService $approvalEmail,
+        private readonly SupportGmailIngestFilter $ingestFilter,
     ) {
     }
 
@@ -29,6 +30,8 @@ class GmailIngestService
      *   ingested: int,
      *   duplicates: int,
      *   skipped_untrusted: int,
+     *   skipped_system: int,
+     *   skipped_non_ticket: int,
      *   approvals_processed: int,
      *   cursor_updated: bool,
      *   warnings: string[]
@@ -71,9 +74,16 @@ class GmailIngestService
             $ingested = 0;
             $duplicates = 0;
             $skippedUntrusted = 0;
+            $skippedSystem = 0;
+            $skippedNonTicket = 0;
             $approvalsProcessed = 0;
 
             foreach ($result['messages'] as $msg) {
+                if ($this->ingestFilter->isSystemOutbound($msg)) {
+                    $skippedSystem++;
+                    continue;
+                }
+
                 if ($this->allowlist->isAllowed($msg->from)) {
                     $approvalResult = $this->approvalEmail->processApprovalReply($msg, (string) $msg->from);
                     if ($approvalResult !== null) {
@@ -84,6 +94,11 @@ class GmailIngestService
 
                 if (!$this->allowlist->isAllowed($msg->from)) {
                     $skippedUntrusted++;
+                    continue;
+                }
+
+                if (!$this->ingestFilter->isTicketSubject($msg->subject)) {
+                    $skippedNonTicket++;
                     continue;
                 }
 
@@ -131,6 +146,8 @@ class GmailIngestService
                 'ingested' => $ingested,
                 'duplicates' => $duplicates,
                 'skipped_untrusted' => $skippedUntrusted,
+                'skipped_system' => $skippedSystem,
+                'skipped_non_ticket' => $skippedNonTicket,
                 'approvals_processed' => $approvalsProcessed,
                 'cursor_updated' => true,
                 'warnings' => $result['warnings'] ?? [],
@@ -141,7 +158,7 @@ class GmailIngestService
     }
 
     /**
-     * @return array{ingested: int, duplicates: int, skipped_untrusted: int, approvals_processed: int, cursor_updated: bool, warnings: string[]}
+     * @return array{ingested: int, duplicates: int, skipped_untrusted: int, skipped_system: int, skipped_non_ticket: int, approvals_processed: int, cursor_updated: bool, warnings: string[]}
      */
     private function emptyResult(): array
     {
@@ -149,6 +166,8 @@ class GmailIngestService
             'ingested' => 0,
             'duplicates' => 0,
             'skipped_untrusted' => 0,
+            'skipped_system' => 0,
+            'skipped_non_ticket' => 0,
             'approvals_processed' => 0,
             'cursor_updated' => false,
             'warnings' => [],

--- a/app/Services/Support/Gmail/SupportGmailIngestFilter.php
+++ b/app/Services/Support/Gmail/SupportGmailIngestFilter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Support\Gmail;
+
+use App\Services\Support\SupportEmailAddress;
+
+/**
+ * Decides which Gmail messages are tickets, approvals, or system noise.
+ */
+final class SupportGmailIngestFilter
+{
+    public function isSystemOutbound(GmailMessage $message): bool
+    {
+        $from = SupportEmailAddress::fromHeader((string) $message->from);
+        $notify = SupportEmailAddress::normalize((string) config('support_gmail.notify_email'));
+
+        return $from !== null && $notify !== null && $from === $notify;
+    }
+
+    public function isTicketSubject(?string $subject): bool
+    {
+        $prefix = strtolower(trim((string) config('support_gmail.subject_prefix', '')));
+        if ($prefix === '') {
+            return false;
+        }
+
+        return str_contains(strtolower((string) $subject), $prefix);
+    }
+}

--- a/app/Services/Support/Gmail/SupportGmailPollQuery.php
+++ b/app/Services/Support/Gmail/SupportGmailPollQuery.php
@@ -20,7 +20,13 @@ final class SupportGmailPollQuery
             // Ingest new tickets (codeweek-support) and APPROVE replies (Re: [CW-SUPPORT #…]).
             $subjectFilters = ['subject:'.self::quoteGmailSearchTerm($prefix)];
             if ($approvalPrefix !== '' && !self::sameSearchTerm($prefix, $approvalPrefix)) {
-                $subjectFilters[] = 'subject:'.self::quoteGmailSearchTerm($approvalPrefix);
+                $approvalSubject = 'subject:'.self::quoteGmailSearchTerm($approvalPrefix);
+                $notify = trim((string) config('support_gmail.notify_email'));
+                if ($notify !== '') {
+                    // Exclude our own dry-run / completion emails from the approval poll.
+                    $approvalSubject .= ' -from:'.self::quoteGmailFromAddress($notify);
+                }
+                $subjectFilters[] = $approvalSubject;
             }
             $parts[] = count($subjectFilters) === 1
                 ? $subjectFilters[0]
@@ -55,5 +61,10 @@ final class SupportGmailPollQuery
     private static function sameSearchTerm(string $a, string $b): bool
     {
         return strcasecmp(trim($a), trim($b)) === 0;
+    }
+
+    private static function quoteGmailFromAddress(string $email): string
+    {
+        return self::quoteGmailSearchTerm(trim($email));
     }
 }

--- a/tests/Unit/Support/GmailIngestServiceTest.php
+++ b/tests/Unit/Support/GmailIngestServiceTest.php
@@ -31,6 +31,7 @@ final class GmailIngestServiceTest extends TestCase
             logger: app(SupportActionLogger::class),
             allowlist: app(SupportSenderAllowlist::class),
             approvalEmail: $approvalEmail,
+            ingestFilter: app(\App\Services\Support\Gmail\SupportGmailIngestFilter::class),
         );
     }
 
@@ -45,6 +46,7 @@ final class GmailIngestServiceTest extends TestCase
         config()->set('support_gmail.label', 'Support-AI');
         config()->set('support_gmail.query', 'newer_than:7d');
         config()->set('support_gmail.allowed_sender_domains', ['matrixinternet.ie']);
+        config()->set('support_gmail.subject_prefix', 'codeweek-support');
 
         $fakeConnector = new class implements GmailConnector {
             public function fetchNewMessages(
@@ -56,9 +58,9 @@ final class GmailIngestServiceTest extends TestCase
             ): array {
                 return [
                     'messages' => [
-                        new GmailMessage('m1', 't1', 'Subj 1', 'sender@matrixinternet.ie', "Hello 1"),
-                        new GmailMessage('m1', 't1', 'Subj 1', 'sender@matrixinternet.ie', "Hello 1 DUP"),
-                        new GmailMessage('m2', 't2', 'Subj 2', 'other@matrixinternet.ie', "Hello 2"),
+                        new GmailMessage('m1', 't1', 'codeweek-support ticket 1', 'sender@matrixinternet.ie', "Hello 1"),
+                        new GmailMessage('m1', 't1', 'codeweek-support ticket 1', 'sender@matrixinternet.ie', "Hello 1 DUP"),
+                        new GmailMessage('m2', 't2', 'codeweek-support ticket 2', 'other@matrixinternet.ie', "Hello 2"),
                     ],
                     'next_history_id' => '123',
                     'warnings' => [],
@@ -138,6 +140,67 @@ final class GmailIngestServiceTest extends TestCase
         $this->assertFalse($res['cursor_updated']);
 
         $lock->release();
+    }
+
+    public function test_poll_skips_system_outbound_and_processes_approve_reply(): void
+    {
+        config()->set('support_gmail.enabled', true);
+        config()->set('support_gmail.lock.name', 'test:support:gmail:poll:approve');
+        config()->set('support_gmail.lock.ttl_seconds', 30);
+        config()->set('support_gmail.notify_email', 'codeweek@matrixinternet.ie');
+        config()->set('support_gmail.allowed_sender_domains', ['matrixinternet.ie']);
+        config()->set('support_gmail.subject_prefix', 'codeweek-support');
+
+        $approvalEmail = $this->createMock(SupportApprovalEmailService::class);
+        $approvalEmail->expects($this->once())
+            ->method('processApprovalReply')
+            ->willReturn(['ok' => true, 'tool' => 'support_email_approval']);
+
+        $fakeConnector = new class implements GmailConnector {
+            public function fetchNewMessages(
+                string $mailbox,
+                ?string $label,
+                string $query,
+                ?string $sinceHistoryId,
+                int $max = 25,
+            ): array {
+                return [
+                    'messages' => [
+                        new GmailMessage(
+                            'bot1',
+                            't-bot',
+                            '[CW-SUPPORT #20] Support copilot - dry run review',
+                            'codeweek@matrixinternet.ie',
+                            'dry run body',
+                        ),
+                        new GmailMessage(
+                            'approve1',
+                            't-approve',
+                            'Re: [CW-SUPPORT #20] Support copilot - dry run review',
+                            'bernard@matrixinternet.ie',
+                            "APPROVE\n",
+                        ),
+                    ],
+                    'next_history_id' => null,
+                    'warnings' => [],
+                ];
+            }
+        };
+
+        $svc = new GmailIngestService(
+            connector: $fakeConnector,
+            intake: app(CaseIntakeService::class),
+            logger: app(SupportActionLogger::class),
+            allowlist: app(SupportSenderAllowlist::class),
+            approvalEmail: $approvalEmail,
+            ingestFilter: app(\App\Services\Support\Gmail\SupportGmailIngestFilter::class),
+        );
+
+        $res = $svc->pollAndIngest(25);
+
+        $this->assertSame(1, $res['approvals_processed']);
+        $this->assertSame(1, $res['skipped_system']);
+        $this->assertSame(0, $res['ingested']);
     }
 
     public function test_poll_passes_through_connector_warnings(): void

--- a/tests/Unit/Support/SupportGmailPollQueryTest.php
+++ b/tests/Unit/Support/SupportGmailPollQueryTest.php
@@ -12,8 +12,10 @@ final class SupportGmailPollQueryTest extends TestCase
         config()->set('support_gmail.subject_prefix', 'codeweek-support');
         config()->set('support_gmail.query', 'newer_than:90d');
 
+        config()->set('support_gmail.notify_email', 'codeweek@matrixinternet.ie');
+
         $this->assertSame(
-            '(subject:codeweek-support OR subject:"[CW-SUPPORT") newer_than:90d',
+            '(subject:codeweek-support OR subject:"[CW-SUPPORT" -from:codeweek@matrixinternet.ie) newer_than:90d',
             SupportGmailPollQuery::resolve(),
         );
     }


### PR DESCRIPTION
Fixes approval_processed:0 caused by ingesting Code Week Bot dry-run emails as new tickets.

Made with [Cursor](https://cursor.com)