### PR TITLE
Restrict grassroots grants to signed preview URLs while unpublished.

### DIFF
--- a/app/GrassrootsGrantsPage.php
+++ b/app/GrassrootsGrantsPage.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\URL;
 
 class GrassrootsGrantsPage extends Model
 {
@@ -52,5 +53,13 @@ class GrassrootsGrantsPage extends Model
             'meta_description' => 'Discover EU Code Week Round 1 grassroots grant projects, impact, and funded initiatives across Europe.',
             'round_title' => 'Round 1 of Grants',
         ]);
+    }
+
+    public function previewSignedUrl(int $days = 14): string
+    {
+        return URL::temporarySignedRoute(
+            'grassroots-grants.preview',
+            now()->addDays($days),
+        );
     }
 }

--- a/app/Http/Controllers/GrassrootsGrantsController.php
+++ b/app/Http/Controllers/GrassrootsGrantsController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\GrassrootsGrantsPage;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\View\View;
+
+class GrassrootsGrantsController extends Controller
+{
+    public function show(): View
+    {
+        $page = $this->loadPage();
+
+        if ($page->is_preview_mode) {
+            abort(404);
+        }
+
+        return view('static.grassroots-grants', [
+            'page' => $page,
+            'previewMode' => false,
+        ]);
+    }
+
+    public function preview(): View
+    {
+        return view('static.grassroots-grants', [
+            'page' => $this->loadPage(),
+            'previewMode' => true,
+        ]);
+    }
+
+    private function loadPage(): GrassrootsGrantsPage
+    {
+        return GrassrootsGrantsPage::config()->load([
+            'activeHubs.activeProjects.links',
+            'activeHubs.activeProjects.images',
+        ]);
+    }
+}

--- a/app/Nova/GrassrootsGrantsPage.php
+++ b/app/Nova/GrassrootsGrantsPage.php
@@ -53,7 +53,19 @@ class GrassrootsGrantsPage extends Resource
 
             Panel::make('Publishing', [
                 Boolean::make('Preview mode', 'is_preview_mode')
-                    ->help('When enabled, the page shows a preview banner and the footer link stays hidden.'),
+                    ->help('When enabled, /grassroots-grants returns 404 and only the signed preview URL below works. The footer link stays hidden until preview mode is off.'),
+                Text::make('Preview URL', function () {
+                    if (! $this->resource?->exists) {
+                        return 'Save first to generate preview URL.';
+                    }
+
+                    $url = $this->resource->previewSignedUrl();
+
+                    return '<a href="'.$url.'" target="_blank" rel="noopener noreferrer">'.$url.'</a>';
+                })
+                    ->onlyOnDetail()
+                    ->asHtml()
+                    ->help('Share this signed link for review. It expires in 14 days. Regenerate by reopening this page in Nova.'),
             ])->collapsable(),
 
             Panel::make('Hero', [

--- a/resources/views/static/grassroots-grants.blade.php
+++ b/resources/views/static/grassroots-grants.blade.php
@@ -58,10 +58,10 @@
 
 @section('content')
     <section id="codeweek-grassroots-grants" class="font-['Blinker'] overflow-hidden">
-        @if($page && $page->is_preview_mode)
+        @if(($previewMode ?? false) === true)
             <div class="bg-yellow-100 border-b border-yellow-300 text-[#20262C]">
                 <div class="codeweek-container-lg py-3 text-sm md:text-base font-medium">
-                    Preview mode: this page is not published yet.
+                    Preview mode: this page is not published yet. Share only the signed preview link from Nova.
                 </div>
             </div>
         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -236,8 +236,11 @@ Route::get('/contact-us', [StaticPageController::class, 'static'])
      ->name('contact-us');
 Route::get('/faqs', [StaticPageController::class, 'static'])
      ->name('faqs');
-Route::get('/grassroots-grants', [StaticPageController::class, 'static'])
+Route::get('/grassroots-grants', [\App\Http\Controllers\GrassrootsGrantsController::class, 'show'])
      ->name('grassroots-grants');
+Route::get('/grassroots-grants-preview', [\App\Http\Controllers\GrassrootsGrantsController::class, 'preview'])
+     ->middleware('signed')
+     ->name('grassroots-grants.preview');
 //Static training pages
 Route::get('/training', [TrainingController::class, 'index'])->name('training.index');
 Route::get(


### PR DESCRIPTION
Return 404 on /grassroots-grants during preview mode and expose a temporary signed Nova preview link for stakeholders.