### PR TITLE
Fix duplicate status label on grassroots grants hubs.

### DIFF
--- a/app/GrassrootsGrantsHub.php
+++ b/app/GrassrootsGrantsHub.php
@@ -77,17 +77,38 @@ class GrassrootsGrantsHub extends Model
 
     public function statusBodyHtml(): string
     {
-        $message = trim(strip_tags((string) ($this->status_message ?? ''), '<p><br><strong><em><a><ul><ol><li>'));
+        $message = trim((string) ($this->status_message ?? ''));
         if ($message !== '') {
-            if (str_contains((string) $this->status_message, '<')) {
-                return (string) $this->status_message;
-            }
-
-            return '<p>'.e($message).'</p>';
+            return $this->stripEmbeddedStatusLine($message);
         }
 
-        $overview = trim((string) ($this->overview ?? ''));
+        return $this->stripEmbeddedStatusLine(trim((string) ($this->overview ?? '')));
+    }
 
-        return $overview;
+    private function stripEmbeddedStatusLine(string $html): string
+    {
+        if ($html === '') {
+            return '';
+        }
+
+        $cleaned = preg_replace(
+            '/<p>\s*<strong>\s*Status:\s*<\/strong>[^<]*<\/p>\s*/iu',
+            '',
+            $html
+        ) ?? $html;
+
+        $plain = trim(strip_tags($cleaned));
+        $plain = preg_replace('/^Status:\s*.+?(?:\n|$)/iu', '', $plain) ?? $plain;
+        $plain = trim($plain);
+
+        if ($plain === '') {
+            return '';
+        }
+
+        if (str_contains($cleaned, '<')) {
+            return trim($cleaned);
+        }
+
+        return '<p>'.e($plain).'</p>';
     }
 }

--- a/resources/views/static/grassroots-grants.blade.php
+++ b/resources/views/static/grassroots-grants.blade.php
@@ -145,9 +145,6 @@
                                 <div class="overflow-hidden max-h-0 transition-all duration-300">
                                     <div class="pb-6 pt-2 text-[#333E48] text-lg md:text-xl font-normal grants-content">
                                         @if($hub->isStatusOnly())
-                                            @if($statusLabel = $hub->statusLabel())
-                                                <p class="mb-4"><strong>Status:</strong> {{ $statusLabel }}</p>
-                                            @endif
                                             @if($statusBody = $hub->statusBodyHtml())
                                                 <div>{!! $statusBody !!}</div>
                                             @endif


### PR DESCRIPTION
Show the status line once in the accordion header and strip any embedded Status paragraph from the expanded body content.