### PR TITLE
Allow HTML links in homepage slider descriptions from Nova.

### DIFF
--- a/app/HomeSlide.php
+++ b/app/HomeSlide.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Stevebauman\Purify\Facades\Purify;
 
 class HomeSlide extends Model
 {
@@ -92,6 +93,18 @@ class HomeSlide extends Model
         }
         $val = $this->button2_text;
         return $val === null || $val === '' ? null : (string) __($val);
+    }
+
+    /**
+     * Sanitize homepage slide description HTML, allowing only safe links.
+     */
+    public static function sanitizeDescriptionHtml(string $html): string
+    {
+        if ($html === '') {
+            return '';
+        }
+
+        return (string) Purify::config('home_slide')->clean($html);
     }
 
     public function scopeActive($query)

--- a/app/Nova/HomeSlide.php
+++ b/app/Nova/HomeSlide.php
@@ -243,7 +243,7 @@ class HomeSlide extends Resource
 
             Textarea::make('Description', 'description')
                 ->nullable()
-                ->help('Lang key (e.g. home.banner4_description) or plain text. Translated via resources/lang per locale.'),
+                ->help('Lang key (e.g. home.banner4_description) or plain text. HTML links allowed, e.g. Check our <a href="https://codeweek.eu/dream-jobs-in-digital">Careers in Digital page</a>! Translated via resources/lang per locale.'),
 
             Text::make('Primary button URL', 'url')->rules('required')->hideFromIndex(),
             Text::make('Primary button label', 'button_text')

--- a/config/purify.php
+++ b/config/purify.php
@@ -49,6 +49,18 @@ return [
             'AutoFormat.RemoveEmpty' => false,
         ],
 
+        'home_slide' => [
+            'Core.Encoding' => 'utf-8',
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
+            'HTML.Allowed' => 'a[href|target|rel]',
+            'HTML.ForbiddenElements' => '',
+            'CSS.AllowedProperties' => '',
+            'AutoFormat.AutoParagraph' => false,
+            'AutoFormat.RemoveEmpty' => false,
+            'Attr.AllowedFrameTargets' => ['_blank'],
+            'URI.AllowedSchemes' => ['http' => true, 'https' => true, 'mailto' => true],
+        ],
+
     ],
 
     /*

--- a/resources/views/static/home.blade.php
+++ b/resources/views/static/home.blade.php
@@ -93,8 +93,8 @@
                                     {{ __($activity['title']) }}
                                 </h2>
                                 <p
-                                    class="text-xl md:text-2xl leading-8 text-[#333E48] p-0 mb-4 max-md:max-w-full max-w-[525px]">
-                                    {{ strip_tags(__($activity['description'] ?? '')) }}
+                                    class="text-xl md:text-2xl leading-8 text-[#333E48] p-0 mb-4 max-md:max-w-full max-w-[525px] [&_a]:text-[#1C4DA1] [&_a]:font-semibold [&_a]:underline hover:[&_a]:opacity-80">
+                                    {!! \App\HomeSlide::sanitizeDescriptionHtml(__($activity['description'] ?? '')) !!}
                                 </p>
                                 <div class="flex flex-col space-y-4 md:flex-row md:space-x-4 md:space-y-0">
                                     <a class="inline-block bg-primary hover:bg-hover-orange rounded-full py-4 px-6 md:px-10 font-semibold text-base w-full md:w-auto text-center text-[#20262C] transition-all duration-300"


### PR DESCRIPTION
Sanitize descriptions to permit safe anchor tags and style them with the site blue link treatment so editors can add inline links without extra buttons.