### PR TITLE
Use Trix WYSIWYG for homepage slider descriptions in Nova.

### DIFF
--- a/app/HomeSlide.php
+++ b/app/HomeSlide.php
@@ -71,7 +71,22 @@ class HomeSlide extends Model
         if (! empty($overrides[$locale]['description'])) {
             return (string) $overrides[$locale]['description'];
         }
-        return (string) __($this->description ?? '');
+
+        return (string) ($this->description ?? '');
+    }
+
+    /**
+     * Resolve lang keys to translated strings, or return rich text / plain content as stored.
+     */
+    public static function resolveLocalizedRichText(string $value): string
+    {
+        $plain = trim(strip_tags($value));
+
+        if ($plain !== '' && $plain === trim($value) && str_contains($plain, '.') && ! str_contains($plain, ' ')) {
+            return (string) __($plain);
+        }
+
+        return $value;
     }
 
     public function buttonTextForLocale(?string $locale = null): string
@@ -96,12 +111,18 @@ class HomeSlide extends Model
     }
 
     /**
-     * Sanitize homepage slide description HTML, allowing only safe links.
+     * Sanitize homepage slide description HTML, allowing Trix-style formatting and links.
      */
     public static function sanitizeDescriptionHtml(string $html): string
     {
         if ($html === '') {
             return '';
+        }
+
+        $html = trim($html);
+
+        if ($html === strip_tags($html)) {
+            return nl2br(e($html), false);
         }
 
         return (string) Purify::config('home_slide')->clean($html);

--- a/app/Nova/HomeSlide.php
+++ b/app/Nova/HomeSlide.php
@@ -10,6 +10,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
+use Laravel\Nova\Fields\Trix;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use App\Nova\Actions\ExportHomeSlideLocaleOverrides;
@@ -174,6 +175,7 @@ class HomeSlide extends Resource
                 ->nullable()
                 ->onlyOnForms()
                 ->hideFromIndex()
+                ->help('Plain text or HTML (line breaks and links supported). Copy from the English Trix editor if needed.')
                 ->resolveUsing(function () use ($locale) {
                     $overrides = $this->resource->locale_overrides ?? [];
                     return $overrides[$locale]['description'] ?? '';
@@ -241,9 +243,9 @@ class HomeSlide extends Resource
                 ->rules('required')
                 ->help('Lang key (e.g. home.banner4_title) for automatic translation per locale from resources/lang/en/home.php, or plain text. English is default.'),
 
-            Textarea::make('Description', 'description')
+            Trix::make('Description', 'description')
                 ->nullable()
-                ->help('Lang key (e.g. home.banner4_description) or plain text. HTML links allowed, e.g. Check our <a href="https://codeweek.eu/dream-jobs-in-digital">Careers in Digital page</a>! Translated via resources/lang per locale.'),
+                ->help('Rich text: links, line breaks, and bold text. Or use a lang key (e.g. home.banner4_description) for automatic translation per locale.'),
 
             Text::make('Primary button URL', 'url')->rules('required')->hideFromIndex(),
             Text::make('Primary button label', 'button_text')

--- a/config/purify.php
+++ b/config/purify.php
@@ -52,7 +52,7 @@ return [
         'home_slide' => [
             'Core.Encoding' => 'utf-8',
             'HTML.Doctype' => 'HTML 4.01 Transitional',
-            'HTML.Allowed' => 'a[href|target|rel]',
+            'HTML.Allowed' => 'div,p,br,strong,b,em,i,a[href|target|rel]',
             'HTML.ForbiddenElements' => '',
             'CSS.AllowedProperties' => '',
             'AutoFormat.AutoParagraph' => false,

--- a/resources/views/static/home.blade.php
+++ b/resources/views/static/home.blade.php
@@ -92,10 +92,10 @@
                                     class="text-[#1C4DA1] text-[30px] md:text-[60px] leading-9 md:leading-[72px] font-normal font-['Montserrat'] mb-4 max-w-[525px]">
                                     {{ __($activity['title']) }}
                                 </h2>
-                                <p
-                                    class="text-xl md:text-2xl leading-8 text-[#333E48] p-0 mb-4 max-md:max-w-full max-w-[525px] [&_a]:text-[#1C4DA1] [&_a]:font-semibold [&_a]:underline hover:[&_a]:opacity-80">
-                                    {!! \App\HomeSlide::sanitizeDescriptionHtml(__($activity['description'] ?? '')) !!}
-                                </p>
+                                <div
+                                    class="text-xl md:text-2xl leading-8 text-[#333E48] p-0 mb-4 max-md:max-w-full max-w-[525px] [&_p]:p-0 [&_p]:mb-4 [&_p:last-child]:mb-0 [&_div]:mb-4 [&_div:last-child]:mb-0 [&_a]:text-[#1C4DA1] [&_a]:font-semibold [&_a]:underline hover:[&_a]:opacity-80">
+                                    {!! \App\HomeSlide::sanitizeDescriptionHtml(\App\HomeSlide::resolveLocalizedRichText($activity['description'] ?? '')) !!}
+                                </div>
                                 <div class="flex flex-col space-y-4 md:flex-row md:space-x-4 md:space-y-0">
                                     <a class="inline-block bg-primary hover:bg-hover-orange rounded-full py-4 px-6 md:px-10 font-semibold text-base w-full md:w-auto text-center text-[#20262C] transition-all duration-300"
                                         href="{{ $activity['url'] }}"


### PR DESCRIPTION
Editors get rich text with line breaks and links while the frontend sanitizes Trix output and preserves plain-text line breaks for lang keys and locale overrides.