### PR TITLE
feat(support): add user-role-add action (APPROVE + batch)

### DIFF
--- a/app/Jobs/Support/ExecuteApprovedSupportActionJob.php
+++ b/app/Jobs/Support/ExecuteApprovedSupportActionJob.php
@@ -11,6 +11,7 @@ use App\Services\Support\SupportActionLogger;
 use App\Services\Support\SupportApprovalEmailService;
 use App\Services\Support\UserProfileUpdateService;
 use App\Services\Support\UserRestoreService;
+use App\Services\Support\UserRoleAddService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -33,6 +34,7 @@ class ExecuteApprovedSupportActionJob implements ShouldQueue
         CursorAgentService $cursorAgent,
         ArtisanCommandRunner $artisanRunner,
         ContentUpdateService $contentUpdate,
+        UserRoleAddService $userRoleAdd,
     ): void
     {
         $approval = SupportApproval::findOrFail($this->supportApprovalId);
@@ -87,6 +89,9 @@ class ExecuteApprovedSupportActionJob implements ShouldQueue
         } elseif ($action === 'user_profile_update') {
             // Re-read names from the case email (approval payload may be from an older parser).
             $result = $userProfileUpdate->updateFromCase($case, dryRun: false, viaEmailApproval: true);
+        } elseif ($action === 'user_role_add') {
+            // Re-read the role + emails from the case email at execution time.
+            $result = $userRoleAdd->addFromCase($case, dryRun: false, viaEmailApproval: true);
         } elseif ($action === 'code_change') {
             $result = $cursorAgent->launchCodeAgent(
                 prompt: (string) ($payload['cursor_prompt'] ?? ''),

--- a/app/Jobs/Support/ProcessSupportCaseDiagnosticsJob.php
+++ b/app/Jobs/Support/ProcessSupportCaseDiagnosticsJob.php
@@ -11,6 +11,7 @@ use App\Services\Support\SupportActionLogger;
 use App\Services\Support\SupportJson;
 use App\Services\Support\UserProfileUpdateService;
 use App\Services\Support\UserRestoreService;
+use App\Services\Support\UserRoleAddService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -30,6 +31,7 @@ class ProcessSupportCaseDiagnosticsJob implements ShouldQueue
         SupportActionLogger $logger,
         UserRestoreService $userRestore,
         UserProfileUpdateService $userProfileUpdate,
+        UserRoleAddService $userRoleAdd,
         ArtisanCommandRunner $artisanRunner,
         ContentUpdateService $contentUpdate,
     ): void {
@@ -70,6 +72,20 @@ class ProcessSupportCaseDiagnosticsJob implements ShouldQueue
                 actionName: 'user_profile_update',
                 actionType: 'write',
                 input: ['email' => $case->target_email, 'dry_run' => true],
+                output: $dryRunResult,
+                succeeded: (bool) ($dryRunResult['ok'] ?? false),
+                executedBy: 'agent',
+                correlationId: $case->correlation_id,
+            );
+        }
+
+        if ($case->case_type === 'role_add') {
+            $dryRunResult = $userRoleAdd->addFromCase($case, dryRun: true);
+            $logger->log(
+                case: $case,
+                actionName: 'user_role_add',
+                actionType: 'write',
+                input: ['dry_run' => true],
                 output: $dryRunResult,
                 succeeded: (bool) ($dryRunResult['ok'] ?? false),
                 executedBy: 'agent',

--- a/app/Services/Support/Agents/CursorCliTriageProvider.php
+++ b/app/Services/Support/Agents/CursorCliTriageProvider.php
@@ -27,6 +27,7 @@ class CursorCliTriageProvider implements TriageProvider
         'missing_events',
         'certificate_issue',
         'role_issue',
+        'role_add',
         'code_change',
         'artisan_command',
         'content_update',
@@ -133,6 +134,8 @@ Do NOT make any code changes, run tools, or edit files. Respond with a single JS
 Allowed case_type values: {$types}
 Use "code_change" only when the request is about a bug or change in the website/application code
 (frontend or template/markup/styling/behaviour) that a developer would fix in the repository.
+Use "role_add" when the request is to add/grant a role (e.g. "leading teacher") to one or more
+users identified by email. Put the affected emails in target_email/secondary_emails.
 {$artisanBlock}{$contentBlock}
 JSON schema to return:
 {
@@ -288,6 +291,7 @@ BLOCK;
         $requestedAction = match ($caseType) {
             'profile_update' => 'user_profile_update',
             'account_restore' => 'user_restore',
+            'role_add' => 'user_role_add',
             'code_change' => 'code_change',
             'artisan_command' => 'artisan_command',
             'content_update' => 'content_update',

--- a/app/Services/Support/Agents/TriageAgentService.php
+++ b/app/Services/Support/Agents/TriageAgentService.php
@@ -4,6 +4,7 @@ namespace App\Services\Support\Agents;
 
 use App\Models\Support\SupportCase;
 use App\Services\Support\SupportProfileRequestParser;
+use App\Services\Support\SupportRoleRequestParser;
 use Illuminate\Support\Str;
 
 class TriageAgentService
@@ -11,6 +12,7 @@ class TriageAgentService
     public function __construct(
         private readonly SupportProfileRequestParser $profileParser,
         private readonly CursorCliTriageProvider $aiProvider,
+        private readonly SupportRoleRequestParser $roleParser,
     ) {
     }
 
@@ -56,11 +58,18 @@ class TriageAgentService
         $rawText = (string) ($case->normalized_message ?? $case->raw_message ?? '');
         $text = Str::lower($rawText);
         $profile = $this->profileParser->parse($rawText);
+        $roleRequest = $this->roleParser->parse($rawText);
+        $hasRoleRequest = $roleRequest['role'] !== null
+            && $roleRequest['operation'] === 'add'
+            && $roleRequest['emails'] !== [];
 
         // V1 heuristic placeholder (replace with LLM later, keep output schema stable).
         $caseType = 'unknown';
         $runbook = 'unknown';
-        if (Str::contains($text, ['soft-deleted', 'deleted', 'restore account', 'account missing'])) {
+        if ($hasRoleRequest) {
+            $caseType = 'role_add';
+            $runbook = 'add_user_role';
+        } elseif (Str::contains($text, ['soft-deleted', 'deleted', 'restore account', 'account missing'])) {
             $caseType = 'account_restore';
             $runbook = 'restore_deleted_account';
         } elseif (Str::contains($text, [
@@ -88,17 +97,31 @@ class TriageAgentService
             $runbook = 'role_problem';
         }
 
-        $targetEmail = $profile['email'] ?? $this->extractFirstEmail($text);
-        $secondary = $this->extractAllEmails($text);
-        $secondary = array_values(array_filter($secondary, fn ($e) => $targetEmail ? $e !== $targetEmail : true));
+        if ($hasRoleRequest) {
+            $targetEmail = $roleRequest['emails'][0];
+            $secondary = array_values(array_slice($roleRequest['emails'], 1));
+        } else {
+            $targetEmail = $profile['email'] ?? $this->extractFirstEmail($text);
+            $secondary = $this->extractAllEmails($text);
+            $secondary = array_values(array_filter($secondary, fn ($e) => $targetEmail ? $e !== $targetEmail : true));
+        }
 
         $risk = Str::contains($text, ['password reset', 'merge', 'ownership', 'privileged']) ? 'high' : 'low';
         if ($caseType === 'profile_update') {
             $risk = 'low';
         }
+        if ($hasRoleRequest && $this->roleLooksPrivileged((string) $roleRequest['role'])) {
+            $risk = 'high';
+        }
 
         $needsHuman = $targetEmail === null
             || ($caseType === 'profile_update' && $profile['firstname'] === null && $profile['lastname'] === null);
+
+        $requestedAction = match ($caseType) {
+            'profile_update' => 'user_profile_update',
+            'role_add' => 'user_role_add',
+            default => null,
+        };
 
         return [
             'case_type' => $caseType,
@@ -106,7 +129,7 @@ class TriageAgentService
             'target_email' => $targetEmail,
             'secondary_emails' => $secondary,
             'target_user_id' => null,
-            'requested_action' => $caseType === 'profile_update' ? 'user_profile_update' : null,
+            'requested_action' => $requestedAction,
             'profile_firstname' => $profile['firstname'],
             'profile_lastname' => $profile['lastname'],
             'risk_level' => $risk,
@@ -118,6 +141,11 @@ class TriageAgentService
             'cursor_prompt' => null,
             'triage_source' => 'heuristic',
         ];
+    }
+
+    private function roleLooksPrivileged(string $roleName): bool
+    {
+        return (bool) preg_match('/\b(admin|administrator|super|owner|root|staff)\b/i', $roleName);
     }
 
     private function extractFirstEmail(string $text): ?string

--- a/app/Services/Support/SupportApprovalEmailService.php
+++ b/app/Services/Support/SupportApprovalEmailService.php
@@ -15,6 +15,7 @@ class SupportApprovalEmailService
         private readonly GmailOutboundService $gmail,
         private readonly SupportSenderAllowlist $allowlist,
         private readonly SupportProfileRequestParser $profileParser,
+        private readonly SupportRoleRequestParser $roleParser,
     ) {
     }
 
@@ -24,6 +25,7 @@ class SupportApprovalEmailService
         $headline = match ($case->case_type) {
             'profile_update' => 'Please review — name change',
             'account_restore' => 'Please review — account restore',
+            'role_add' => 'Please review — add user role',
             'code_change' => 'Please review — proposed code fix (PR into dev)',
             'artisan_command' => 'Please review — proposed server maintenance command',
             'content_update' => 'Please review — proposed content/copy change',
@@ -280,6 +282,20 @@ class SupportApprovalEmailService
             }
         }
 
+        if ($case->case_type === 'role_add') {
+            $role = $this->roleParser->parse((string) ($case->normalized_message ?? $case->raw_message ?? ''));
+            if ($role['role'] !== null && $role['emails'] !== []) {
+                return [
+                    'action' => 'user_role_add',
+                    'payload' => [
+                        'operation' => 'add',
+                        'role' => $role['role'],
+                        'emails' => $role['emails'],
+                    ],
+                ];
+            }
+        }
+
         if ($case->case_type === 'code_change') {
             $plan = $this->codeChangePlan($case);
             if (($plan['cursor_prompt'] ?? '') !== '') {
@@ -498,11 +514,104 @@ class SupportApprovalEmailService
             return $this->dryRunContentLines($case);
         }
 
+        if ($action === 'user_role_add') {
+            return $this->dryRunRoleAddLines($case, $payload);
+        }
+
         return [
             '',
             'We could not determine an automatic change from this email.',
             'Check that the message includes lines like "Requested first name:" and "Requested last name:".',
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return list<string>
+     */
+    private function dryRunRoleAddLines(SupportCase $case, array $payload): array
+    {
+        $output = $case->actions()
+            ->where('action_name', 'user_role_add')
+            ->where('action_type', 'write')
+            ->latest()
+            ->first()?->output_json;
+
+        $result = is_array($output) ? ($output['result'] ?? []) : [];
+        $role = (string) ($result['role'] ?? $payload['role'] ?? 'the requested role');
+        $items = is_array($result['items'] ?? null) ? $result['items'] : [];
+        $summary = is_array($result['summary'] ?? null) ? $result['summary'] : [];
+
+        $lines = [
+            '',
+            'We will add the role "'.$role.'" to the following CodeWeek accounts:',
+            '',
+        ];
+
+        if ($items === []) {
+            $emails = (array) ($payload['emails'] ?? []);
+            foreach ($emails as $email) {
+                $lines[] = '  • '.$email;
+            }
+            $lines[] = '';
+            $lines[] = 'We will add the role to each account above that does not already have it.';
+
+            return $lines;
+        }
+
+        foreach ($items as $item) {
+            $lines[] = '  • '.$this->roleItemLine((array) $item);
+        }
+
+        $lines[] = '';
+        $lines[] = 'Summary: '.$this->roleSummaryLine($summary);
+
+        if (($summary['ambiguous'] ?? 0) > 0 || ($summary['user_not_found'] ?? 0) > 0) {
+            $lines[] = '';
+            $lines[] = 'Accounts marked "not found" or "needs manual check" will be skipped.';
+            $lines[] = 'Approving will still add the role to all accounts that are ready.';
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function roleItemLine(array $item): string
+    {
+        $email = (string) ($item['email'] ?? '');
+        $status = (string) ($item['status'] ?? '');
+
+        $label = match ($status) {
+            'would_add', 'added' => 'will be added',
+            'already_has_role' => 'already has this role (no change)',
+            'user_not_found' => 'no CodeWeek account found — skipped',
+            'ambiguous' => 'multiple accounts match — needs manual check, skipped',
+            default => $status,
+        };
+
+        return $email.' — '.$label;
+    }
+
+    /**
+     * @param array<string, mixed> $summary
+     */
+    private function roleSummaryLine(array $summary): string
+    {
+        $toAdd = (int) (($summary['would_add'] ?? 0) + ($summary['added'] ?? 0));
+        $parts = [$toAdd.' to add'];
+        if (($summary['already_has_role'] ?? 0) > 0) {
+            $parts[] = (int) $summary['already_has_role'].' already have it';
+        }
+        if (($summary['user_not_found'] ?? 0) > 0) {
+            $parts[] = (int) $summary['user_not_found'].' not found';
+        }
+        if (($summary['ambiguous'] ?? 0) > 0) {
+            $parts[] = (int) $summary['ambiguous'].' need manual check';
+        }
+
+        return implode(', ', $parts).'.';
     }
 
     /**
@@ -685,6 +794,7 @@ class SupportApprovalEmailService
         return match ($action) {
             'user_profile_update' => 'Done — name updated on CodeWeek account',
             'user_restore' => 'Done — CodeWeek account reactivated',
+            'user_role_add' => 'Done — user role added',
             'code_change' => 'Started — AI coding agent is preparing a PR into dev',
             'artisan_command' => 'Done — maintenance command completed on the server',
             'content_update' => 'Done — content updated',
@@ -729,7 +839,8 @@ class SupportApprovalEmailService
             $lines = array_merge($lines, $this->completionFailureLines($action, $result, $email, $case->id));
         }
 
-        if ($email !== '') {
+        // Role-add is a batch action; the per-account list is shown above, so skip the single email line.
+        if ($email !== '' && $action !== 'user_role_add') {
             $lines[] = '';
             $lines[] = 'Account email: '.$email;
         }
@@ -740,8 +851,12 @@ class SupportApprovalEmailService
 
         $lines[] = '';
         if ($succeeded) {
-            $lines[] = 'No further action is needed. The supporter can sign in with their usual email and password.';
-            $lines[] = 'You do not need to reply to this email.';
+            $lines[] = $action === 'user_role_add'
+                ? 'No further action is needed. You do not need to reply to this email.'
+                : 'No further action is needed. The supporter can sign in with their usual email and password.';
+            if ($action !== 'user_role_add') {
+                $lines[] = 'You do not need to reply to this email.';
+            }
         } else {
             $lines[] = 'The change was not applied automatically. Please review this case in Nova or ask the technical team for help.';
             $lines[] = 'When escalating, include reference Case #'.$case->id.'.';
@@ -862,9 +977,45 @@ class SupportApprovalEmailService
             return $lines;
         }
 
+        if ($action === 'user_role_add') {
+            return $this->completionRoleAddLines($inner);
+        }
+
         return [
             'The approved request for case #'.$case->id.' was completed successfully.',
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $inner
+     * @return list<string>
+     */
+    private function completionRoleAddLines(array $inner): array
+    {
+        $role = (string) ($inner['role'] ?? 'the requested role');
+        $items = is_array($inner['items'] ?? null) ? $inner['items'] : [];
+        $summary = is_array($inner['summary'] ?? null) ? $inner['summary'] : [];
+        $addedCount = (int) ($summary['added'] ?? 0);
+
+        $lines = [
+            $addedCount === 1
+                ? 'We added the role "'.$role.'" to 1 CodeWeek account.'
+                : 'We added the role "'.$role.'" to '.$addedCount.' CodeWeek accounts.',
+            '',
+            'Details:',
+        ];
+
+        foreach ($items as $item) {
+            $lines[] = '  • '.$this->roleItemLine((array) $item);
+        }
+
+        $skipped = (int) ($summary['user_not_found'] ?? 0) + (int) ($summary['ambiguous'] ?? 0);
+        if ($skipped > 0) {
+            $lines[] = '';
+            $lines[] = 'Some accounts were skipped (not found or needing manual review). See the list above.';
+        }
+
+        return $lines;
     }
 
     /**
@@ -950,6 +1101,11 @@ class SupportApprovalEmailService
             str_starts_with($code, 'value_contains_markup') => 'The new text contained HTML/markup, which is not allowed for content edits.',
             str_starts_with($code, 'value_too_long') => 'The new text was too long.',
             str_contains($code, 'no_effective_change') => 'The content already matched the requested text — no change was needed.',
+            str_starts_with($code, 'role_not_found') => 'We could not find a matching role. Check the role name (e.g. "leading teacher").',
+            str_starts_with($code, 'role_not_allowed') => 'That role is not on the list the copilot is allowed to add.',
+            str_contains($code, 'no_role_specified') => 'The request did not say which role to add.',
+            str_contains($code, 'no_target_emails') => 'The request did not include any valid email addresses.',
+            str_contains($code, 'only_add_operation') => 'Only adding roles is supported right now (not removing).',
             $action === 'user_restore' && str_contains($code, 'verification') => 'The account was changed but we could not confirm it is fully active. Please verify in Nova.',
             default => 'Technical detail: '.$code,
         };

--- a/app/Services/Support/SupportRoleRequestParser.php
+++ b/app/Services/Support/SupportRoleRequestParser.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Services\Support;
+
+use Illuminate\Support\Str;
+
+/**
+ * Extract a role-change request (operation + role + target emails) from support ticket text.
+ *
+ * Supports two styles:
+ *   1) A labelled block:
+ *        Add role: leading teacher
+ *        Emails:
+ *        a@example.com
+ *        b@example.com
+ *   2) A pasted table (tab- or multi-space separated), one person per line:
+ *        Italy   Antonio Delli   antonio@example.com   add   leading teachers   19-Jun-26
+ */
+final class SupportRoleRequestParser
+{
+    /**
+     * @return array{operation: string, role: ?string, emails: list<string>}
+     */
+    public function parse(string $text): array
+    {
+        $normalized = Str::of($text)->replace("\r\n", "\n")->toString();
+
+        $labelled = $this->parseLabelled($normalized);
+        if ($labelled['role'] !== null && $labelled['emails'] !== []) {
+            return $labelled;
+        }
+
+        $tabular = $this->parseTabular($normalized);
+        if ($tabular['role'] !== null && $tabular['emails'] !== []) {
+            return $tabular;
+        }
+
+        // Fall back to: any explicit role label we found, plus every email in the text.
+        $role = $labelled['role'] ?? $tabular['role'];
+        $emails = $this->extractAllEmails($normalized);
+        $operation = $labelled['operation'] !== 'add' ? $labelled['operation'] : $tabular['operation'];
+
+        return [
+            'operation' => $operation,
+            'role' => $role,
+            'emails' => $emails,
+        ];
+    }
+
+    /**
+     * @return array{operation: string, role: ?string, emails: list<string>}
+     */
+    private function parseLabelled(string $text): array
+    {
+        $operation = 'add';
+        $role = null;
+
+        if (preg_match('/(?:^|\n)\s*(?:add|grant|assign)\s+role\s*[:\-]\s*([^\n\r]+)/iu', $text, $m)) {
+            $role = $this->cleanRole($m[1]);
+            $operation = 'add';
+        } elseif (preg_match('/(?:^|\n)\s*(?:remove|revoke)\s+role\s*[:\-]\s*([^\n\r]+)/iu', $text, $m)) {
+            $role = $this->cleanRole($m[1]);
+            $operation = 'remove';
+        } elseif (preg_match('/(?:^|\n)\s*role\s*(?:to\s+(add|remove))?\s*[:\-]\s*([^\n\r]+)/iu', $text, $m)) {
+            $operation = strtolower(trim($m[1] ?? '')) === 'remove' ? 'remove' : 'add';
+            $role = $this->cleanRole($m[2]);
+        }
+
+        return [
+            'operation' => $operation,
+            'role' => $role,
+            'emails' => $role !== null ? $this->extractAllEmails($text) : [],
+        ];
+    }
+
+    /**
+     * @return array{operation: string, role: ?string, emails: list<string>}
+     */
+    private function parseTabular(string $text): array
+    {
+        $roleCounts = [];
+        $operationCounts = [];
+        $emails = [];
+
+        foreach (explode("\n", $text) as $line) {
+            $email = $this->firstEmail($line);
+            if ($email === null) {
+                continue;
+            }
+
+            $cells = $this->splitColumns($line);
+            $opIndex = null;
+            foreach ($cells as $i => $cell) {
+                $value = strtolower(trim($cell));
+                if (in_array($value, ['add', 'grant', 'assign', 'remove', 'revoke'], true)) {
+                    $opIndex = $i;
+                    $operation = in_array($value, ['remove', 'revoke'], true) ? 'remove' : 'add';
+                    $operationCounts[$operation] = ($operationCounts[$operation] ?? 0) + 1;
+                    break;
+                }
+            }
+
+            if ($opIndex !== null) {
+                for ($j = $opIndex + 1; $j < count($cells); $j++) {
+                    $candidate = $this->cleanRole($cells[$j]);
+                    if ($candidate !== null && ! $this->looksLikeDate($candidate)) {
+                        $roleCounts[$candidate] = ($roleCounts[$candidate] ?? 0) + 1;
+                        break;
+                    }
+                }
+            }
+
+            $emails[] = $email;
+        }
+
+        arsort($roleCounts);
+        arsort($operationCounts);
+
+        return [
+            'operation' => array_key_first($operationCounts) ?: 'add',
+            'role' => array_key_first($roleCounts) ?: null,
+            'emails' => $this->uniqueEmails($emails),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitColumns(string $line): array
+    {
+        if (str_contains($line, "\t")) {
+            $parts = explode("\t", $line);
+        } else {
+            $parts = preg_split('/\s{2,}/', trim($line)) ?: [];
+        }
+
+        return array_values(array_filter(array_map('trim', $parts), fn ($p) => $p !== ''));
+    }
+
+    private function cleanRole(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim(preg_replace('/\s+/', ' ', $value) ?? '');
+        $value = trim($value, " \t.-:");
+
+        if ($value === '' || $this->looksLikeDate($value)) {
+            return null;
+        }
+
+        if (preg_match('/@/', $value)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function looksLikeDate(string $value): bool
+    {
+        return (bool) preg_match('/^\d{1,2}[-\/ ][A-Za-z0-9]{2,}[-\/ ]\d{2,4}$/', trim($value))
+            || (bool) preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($value));
+    }
+
+    private function firstEmail(string $text): ?string
+    {
+        if (preg_match('/[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}/i', $text, $m)) {
+            return strtolower(trim($m[0]));
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractAllEmails(string $text): array
+    {
+        preg_match_all('/[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}/i', $text, $m);
+
+        return $this->uniqueEmails($m[0] ?? []);
+    }
+
+    /**
+     * @param  array<int, string>  $emails
+     * @return list<string>
+     */
+    private function uniqueEmails(array $emails): array
+    {
+        $normalized = array_map(fn ($e) => strtolower(trim($e)), $emails);
+
+        return array_values(array_unique(array_filter($normalized)));
+    }
+}

--- a/app/Services/Support/UserRoleAddService.php
+++ b/app/Services/Support/UserRoleAddService.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Services\Support;
+
+use App\Models\Support\SupportCase;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+
+/**
+ * Add a role to one or more users (batch), with dry-run preview and email-approval gating.
+ *
+ * V1 supports the "add" operation only. Any role that exists in the roles table is allowed
+ * (optionally narrowed by config support_gmail.role_add_allowed_roles).
+ */
+class UserRoleAddService
+{
+    public function __construct(
+        private readonly SupportRoleRequestParser $parser,
+    ) {
+    }
+
+    public function addFromCase(SupportCase $case, bool $dryRun, bool $viaEmailApproval = false): array
+    {
+        $parsed = $this->parser->parse((string) ($case->normalized_message ?? $case->raw_message ?? ''));
+
+        return $this->addRole(
+            case: $case,
+            roleName: $parsed['role'],
+            emails: $parsed['emails'],
+            dryRun: $dryRun,
+            viaEmailApproval: $viaEmailApproval,
+            operation: $parsed['operation'],
+        );
+    }
+
+    /**
+     * @param  list<string>  $emails
+     */
+    public function addRole(
+        SupportCase $case,
+        ?string $roleName,
+        array $emails,
+        bool $dryRun,
+        bool $viaEmailApproval = false,
+        string $operation = 'add',
+    ): array {
+        $tool = 'user_role_add';
+        $input = [
+            'operation' => $operation,
+            'role' => $roleName,
+            'emails' => $emails,
+            'dry_run' => $dryRun,
+        ];
+
+        if ($operation !== 'add') {
+            return SupportJson::fail($tool, $input, 'only_add_operation_supported_in_v1');
+        }
+
+        if ($roleName === null || trim($roleName) === '') {
+            return SupportJson::fail($tool, $input, 'no_role_specified');
+        }
+
+        $role = $this->resolveRole($roleName);
+        if ($role === null) {
+            return SupportJson::fail($tool, $input, 'role_not_found:'.$roleName);
+        }
+
+        if (! $this->roleIsAllowed($role->name)) {
+            return SupportJson::fail($tool, $input, 'role_not_allowed:'.$role->name);
+        }
+
+        $emails = $this->normalizeEmails($emails);
+        if ($emails === []) {
+            return SupportJson::fail($tool, $input, 'no_target_emails');
+        }
+
+        if (! $dryRun && config('support_gmail.dry_run') && ! $viaEmailApproval) {
+            return SupportJson::fail($tool, $input, 'dry_run_mode_requires_email_approval');
+        }
+
+        $items = [];
+        $counts = ['added' => 0, 'would_add' => 0, 'already_has_role' => 0, 'user_not_found' => 0, 'ambiguous' => 0];
+
+        foreach ($emails as $email) {
+            $item = $this->processEmail($case, $role, $email, $dryRun);
+            $items[] = $item;
+            $counts[$item['status']] = ($counts[$item['status']] ?? 0) + 1;
+        }
+
+        $warnings = [];
+        if ($this->roleLooksPrivileged($role->name)) {
+            $warnings[] = 'privileged_role_granted:'.$role->name;
+        }
+
+        return SupportJson::ok($tool, $input, [
+            'operation' => 'add',
+            'role' => $role->name,
+            'dry_run' => $dryRun,
+            'summary' => $counts,
+            'items' => $items,
+        ], $warnings);
+    }
+
+    /**
+     * @return array{email: string, status: string, user_id: ?int, matched_user_ids: list<int>}
+     */
+    private function processEmail(SupportCase $case, Role $role, string $email, bool $dryRun): array
+    {
+        $matches = User::query()
+            ->whereRaw('LOWER(email) = ?', [$email])
+            ->orWhereRaw('LOWER(email_display) = ?', [$email])
+            ->get();
+
+        if ($matches->isEmpty()) {
+            return ['email' => $email, 'status' => 'user_not_found', 'user_id' => null, 'matched_user_ids' => []];
+        }
+
+        if ($matches->count() > 1) {
+            return [
+                'email' => $email,
+                'status' => 'ambiguous',
+                'user_id' => null,
+                'matched_user_ids' => $matches->pluck('id')->map(fn ($id) => (int) $id)->values()->all(),
+            ];
+        }
+
+        /** @var User $user */
+        $user = $matches->first();
+
+        if ($user->hasRole($role->name)) {
+            return ['email' => $email, 'status' => 'already_has_role', 'user_id' => (int) $user->id, 'matched_user_ids' => [(int) $user->id]];
+        }
+
+        if ($dryRun) {
+            return ['email' => $email, 'status' => 'would_add', 'user_id' => (int) $user->id, 'matched_user_ids' => [(int) $user->id]];
+        }
+
+        DB::transaction(fn () => $user->assignRole($role->name));
+
+        return ['email' => $email, 'status' => 'added', 'user_id' => (int) $user->id, 'matched_user_ids' => [(int) $user->id]];
+    }
+
+    private function resolveRole(string $roleName): ?Role
+    {
+        $guard = (string) config('auth.defaults.guard', 'web');
+        $needle = $this->normalizeRoleName($roleName);
+
+        $roles = Role::query()->get();
+
+        $exact = $roles->first(fn (Role $r) => $this->normalizeRoleName($r->name) === $needle && $r->guard_name === $guard)
+            ?? $roles->first(fn (Role $r) => $this->normalizeRoleName($r->name) === $needle);
+        if ($exact !== null) {
+            return $exact;
+        }
+
+        $singular = $this->singularizeRoleName($needle);
+        $bySingular = $roles->first(fn (Role $r) => $this->singularizeRoleName($this->normalizeRoleName($r->name)) === $singular && $r->guard_name === $guard)
+            ?? $roles->first(fn (Role $r) => $this->singularizeRoleName($this->normalizeRoleName($r->name)) === $singular);
+
+        return $bySingular;
+    }
+
+    private function roleIsAllowed(string $roleName): bool
+    {
+        $allowed = config('support_gmail.role_add_allowed_roles', []);
+        $allowed = is_array($allowed) ? array_filter(array_map('trim', $allowed)) : [];
+
+        if ($allowed === []) {
+            return true;
+        }
+
+        $needle = $this->normalizeRoleName($roleName);
+        foreach ($allowed as $candidate) {
+            if ($this->normalizeRoleName((string) $candidate) === $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function roleLooksPrivileged(string $roleName): bool
+    {
+        return (bool) preg_match('/\b(admin|administrator|super|owner|root|staff)\b/i', $roleName);
+    }
+
+    private function normalizeRoleName(string $roleName): string
+    {
+        return Str::of($roleName)->lower()->replaceMatches('/\s+/', ' ')->trim()->toString();
+    }
+
+    private function singularizeRoleName(string $roleName): string
+    {
+        $words = explode(' ', $roleName);
+        $last = array_pop($words);
+        if ($last !== null) {
+            $words[] = Str::singular($last);
+        }
+
+        return implode(' ', $words);
+    }
+
+    /**
+     * @param  list<string>  $emails
+     * @return list<string>
+     */
+    private function normalizeEmails(array $emails): array
+    {
+        $out = [];
+        foreach ($emails as $email) {
+            $normalized = SupportEmailAddress::normalize((string) $email);
+            if ($normalized !== null && $normalized !== '' && filter_var($normalized, FILTER_VALIDATE_EMAIL)) {
+                $out[$normalized] = $normalized;
+            }
+        }
+
+        return array_values($out);
+    }
+}

--- a/config/support_gmail.php
+++ b/config/support_gmail.php
@@ -77,10 +77,18 @@ return [
     'allowed_write_actions' => [
         'user_restore',
         'user_profile_update',
+        'user_role_add',
         'code_change',
         'artisan_command',
         'content_update',
     ],
+
+    // Roles the copilot may add via email APPROVE. Empty = any role that exists in the roles table.
+    // Provide a comma-separated list to restrict (e.g. "leading teacher,leading teacher admin").
+    'role_add_allowed_roles' => array_values(array_filter(array_map(
+        'trim',
+        explode(',', (string) env('SUPPORT_GMAIL_ROLE_ADD_ALLOWED_ROLES', '')),
+    ))),
 
     // Send a follow-up email after an APPROVE action runs (success or failure).
     'send_completion_email' => env('SUPPORT_GMAIL_SEND_COMPLETION_EMAIL', true),

--- a/tests/Unit/Support/SupportApprovalCompletionEmailTest.php
+++ b/tests/Unit/Support/SupportApprovalCompletionEmailTest.php
@@ -8,10 +8,13 @@ use App\Services\Support\Gmail\GmailOutboundService;
 use App\Services\Support\SupportApprovalEmailService;
 use App\Services\Support\SupportProfileRequestParser;
 use App\Services\Support\SupportSenderAllowlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 final class SupportApprovalCompletionEmailTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_completion_subject_reflects_success_or_failure(): void
     {
         $case = new SupportCase(['id' => 10]);
@@ -63,6 +66,7 @@ final class SupportApprovalCompletionEmailTest extends TestCase
             $gmail,
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
+            app(\App\Services\Support\SupportRoleRequestParser::class),
         );
 
         $payload = $svc->sendActionCompletion(

--- a/tests/Unit/Support/SupportCompletionEmailCopyTest.php
+++ b/tests/Unit/Support/SupportCompletionEmailCopyTest.php
@@ -8,10 +8,13 @@ use App\Services\Support\Gmail\GmailOutboundService;
 use App\Services\Support\SupportApprovalEmailService;
 use App\Services\Support\SupportProfileRequestParser;
 use App\Services\Support\SupportSenderAllowlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 final class SupportCompletionEmailCopyTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_completion_body_uses_plain_language_for_profile_update(): void
     {
         $case = SupportCase::create([
@@ -53,6 +56,7 @@ final class SupportCompletionEmailCopyTest extends TestCase
             $gmail,
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
+            app(\App\Services\Support\SupportRoleRequestParser::class),
         );
 
         $svc->sendActionCompletion(

--- a/tests/Unit/Support/SupportDryRunEmailCopyTest.php
+++ b/tests/Unit/Support/SupportDryRunEmailCopyTest.php
@@ -7,10 +7,13 @@ use App\Services\Support\Gmail\GmailOutboundService;
 use App\Services\Support\SupportApprovalEmailService;
 use App\Services\Support\SupportProfileRequestParser;
 use App\Services\Support\SupportSenderAllowlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 final class SupportDryRunEmailCopyTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_dry_run_email_uses_plain_language(): void
     {
         $case = SupportCase::create([
@@ -67,6 +70,7 @@ final class SupportDryRunEmailCopyTest extends TestCase
             $gmail,
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
+            app(\App\Services\Support\SupportRoleRequestParser::class),
         );
 
         $svc->sendDryRunReview($case, 'admin@matrixinternet.ie');
@@ -87,5 +91,68 @@ final class SupportDryRunEmailCopyTest extends TestCase
         $svc = app(SupportApprovalEmailService::class);
 
         $this->assertStringContainsString('Please review — name change', $svc->approvalSubject($case));
+    }
+
+    public function test_dry_run_email_lists_role_add_targets(): void
+    {
+        $case = SupportCase::create([
+            'source_channel' => 'gmail',
+            'processing_mode' => 'automated',
+            'subject' => 'codeweek-support — add leading teachers',
+            'raw_message' => "add role: leading teacher\na@example.com\nb@example.com",
+            'normalized_message' => "add role: leading teacher\na@example.com\nb@example.com",
+            'target_email' => 'a@example.com',
+            'case_type' => 'role_add',
+            'status' => 'diagnosed',
+            'risk_level' => 'low',
+            'correlation_id' => 'cid',
+        ]);
+
+        $case->actions()->create([
+            'action_name' => 'user_role_add',
+            'action_type' => 'write',
+            'input_json' => [],
+            'output_json' => [
+                'ok' => true,
+                'result' => [
+                    'role' => 'leading teacher',
+                    'summary' => ['added' => 0, 'would_add' => 1, 'already_has_role' => 1, 'user_not_found' => 0, 'ambiguous' => 0],
+                    'items' => [
+                        ['email' => 'a@example.com', 'status' => 'would_add', 'user_id' => 1, 'matched_user_ids' => [1]],
+                        ['email' => 'b@example.com', 'status' => 'already_has_role', 'user_id' => 2, 'matched_user_ids' => [2]],
+                    ],
+                ],
+            ],
+            'succeeded' => true,
+            'executed_by' => 'agent',
+        ]);
+
+        $capturedBody = null;
+        $gmail = $this->createMock(GmailOutboundService::class);
+        $gmail->method('sendPlainText')->willReturnCallback(function ($to, $subject, $body) use (&$capturedBody) {
+            $capturedBody = $body;
+
+            return ['id' => 'msg-1', 'thread_id' => 't1'];
+        });
+
+        config([
+            'support_gmail.notify_email' => 'notify@matrixinternet.ie',
+            'support_gmail.allowed_sender_domains' => ['matrixinternet.ie'],
+        ]);
+
+        $svc = new SupportApprovalEmailService(
+            $gmail,
+            app(SupportSenderAllowlist::class),
+            app(SupportProfileRequestParser::class),
+            app(\App\Services\Support\SupportRoleRequestParser::class),
+        );
+
+        $svc->sendDryRunReview($case, 'admin@matrixinternet.ie');
+
+        $this->assertNotNull($capturedBody);
+        $this->assertStringContainsString('add the role "leading teacher"', $capturedBody);
+        $this->assertStringContainsString('a@example.com — will be added', $capturedBody);
+        $this->assertStringContainsString('b@example.com — already has this role', $capturedBody);
+        $this->assertStringNotContainsString('would_add', $capturedBody);
     }
 }

--- a/tests/Unit/Support/SupportRoleRequestParserTest.php
+++ b/tests/Unit/Support/SupportRoleRequestParserTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Services\Support\SupportRoleRequestParser;
+use Tests\TestCase;
+
+final class SupportRoleRequestParserTest extends TestCase
+{
+    public function test_parses_pasted_table_of_leading_teachers(): void
+    {
+        $text = implode("\n", [
+            "Italy\tAntonio Delli Carpini\tdevant.mee@gmail.com\tadd \tleading teachers\t19-Jun-26",
+            "Italy\tmaria chirico\tmariachirico40@gmail.com\tadd \tleading teachers\t19-Jun-26",
+            "France\tNathalie BRAUN\tNathalie.Braun1@ac-nancy-metz.fr\tadd \tleading teachers\t23-Jun-26",
+        ]);
+
+        $parsed = (new SupportRoleRequestParser())->parse($text);
+
+        $this->assertSame('add', $parsed['operation']);
+        $this->assertSame('leading teachers', $parsed['role']);
+        $this->assertSame([
+            'devant.mee@gmail.com',
+            'mariachirico40@gmail.com',
+            'nathalie.braun1@ac-nancy-metz.fr',
+        ], $parsed['emails']);
+    }
+
+    public function test_parses_labelled_request(): void
+    {
+        $text = <<<'TEXT'
+        Add role: leading teacher
+
+        Emails:
+        a@example.com
+        b@example.com
+        TEXT;
+
+        $parsed = (new SupportRoleRequestParser())->parse($text);
+
+        $this->assertSame('add', $parsed['operation']);
+        $this->assertSame('leading teacher', $parsed['role']);
+        $this->assertSame(['a@example.com', 'b@example.com'], $parsed['emails']);
+    }
+
+    public function test_returns_null_role_when_no_role_present(): void
+    {
+        $parsed = (new SupportRoleRequestParser())->parse("Please help a@example.com log in.");
+
+        $this->assertNull($parsed['role']);
+    }
+
+    public function test_deduplicates_emails(): void
+    {
+        $text = "add role: leading teacher\nx@example.com\nX@Example.com\n";
+
+        $parsed = (new SupportRoleRequestParser())->parse($text);
+
+        $this->assertSame(['x@example.com'], $parsed['emails']);
+    }
+}

--- a/tests/Unit/Support/UserRoleAddServiceTest.php
+++ b/tests/Unit/Support/UserRoleAddServiceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Models\Support\SupportCase;
+use App\Services\Support\UserRoleAddService;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+final class UserRoleAddServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeCase(): SupportCase
+    {
+        return SupportCase::create([
+            'source_channel' => 'manual',
+            'processing_mode' => 'manual',
+            'subject' => 'codeweek-support — add leading teachers',
+            'raw_message' => 'test',
+            'status' => 'investigating',
+            'risk_level' => 'low',
+            'correlation_id' => 'cid',
+        ]);
+    }
+
+    public function test_dry_run_plans_role_additions_without_applying(): void
+    {
+        Role::create(['name' => 'leading teacher', 'guard_name' => 'web']);
+        $user = User::factory()->create(['email' => 'lt@example.com']);
+
+        $result = app(UserRoleAddService::class)->addRole(
+            case: $this->makeCase(),
+            roleName: 'leading teachers',
+            emails: ['lt@example.com', 'missing@example.com'],
+            dryRun: true,
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('leading teacher', $result['result']['role']);
+        $this->assertSame(1, $result['result']['summary']['would_add']);
+        $this->assertSame(1, $result['result']['summary']['user_not_found']);
+        $this->assertFalse($user->fresh()->hasRole('leading teacher'));
+    }
+
+    public function test_apply_adds_role_to_existing_users(): void
+    {
+        config(['support_gmail.dry_run' => true]);
+        Role::create(['name' => 'leading teacher', 'guard_name' => 'web']);
+        $a = User::factory()->create(['email' => 'a@example.com']);
+        $b = User::factory()->create(['email' => 'b@example.com']);
+        $b->assignRole('leading teacher');
+
+        $result = app(UserRoleAddService::class)->addRole(
+            case: $this->makeCase(),
+            roleName: 'leading teacher',
+            emails: ['a@example.com', 'b@example.com'],
+            dryRun: false,
+            viaEmailApproval: true,
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(1, $result['result']['summary']['added']);
+        $this->assertSame(1, $result['result']['summary']['already_has_role']);
+        $this->assertTrue($a->fresh()->hasRole('leading teacher'));
+    }
+
+    public function test_apply_blocked_without_email_approval_in_dry_run_mode(): void
+    {
+        config(['support_gmail.dry_run' => true]);
+        Role::create(['name' => 'leading teacher', 'guard_name' => 'web']);
+        User::factory()->create(['email' => 'a@example.com']);
+
+        $result = app(UserRoleAddService::class)->addRole(
+            case: $this->makeCase(),
+            roleName: 'leading teacher',
+            emails: ['a@example.com'],
+            dryRun: false,
+            viaEmailApproval: false,
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('dry_run_mode_requires_email_approval', $result['errors']);
+    }
+
+    public function test_unknown_role_fails(): void
+    {
+        $result = app(UserRoleAddService::class)->addRole(
+            case: $this->makeCase(),
+            roleName: 'wizard',
+            emails: ['a@example.com'],
+            dryRun: true,
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('role_not_found', $result['errors'][0]);
+    }
+
+    public function test_duplicate_email_marked_ambiguous(): void
+    {
+        Role::create(['name' => 'leading teacher', 'guard_name' => 'web']);
+        User::factory()->create(['email' => 'dup@example.com']);
+        User::factory()->create(['email' => 'dup@example.com']);
+
+        $result = app(UserRoleAddService::class)->addRole(
+            case: $this->makeCase(),
+            roleName: 'leading teacher',
+            emails: ['dup@example.com'],
+            dryRun: true,
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(1, $result['result']['summary']['ambiguous']);
+    }
+
+    public function test_role_allowlist_restricts_when_configured(): void
+    {
+        config(['support_gmail.role_add_allowed_roles' => ['leading teacher']]);
+        Role::create(['name' => 'leading teacher', 'guard_name' => 'web']);
+        Role::create(['name' => 'super admin', 'guard_name' => 'web']);
+        User::factory()->create(['email' => 'a@example.com']);
+
+        $result = app(UserRoleAddService::class)->addRole(
+            case: $this->makeCase(),
+            roleName: 'super admin',
+            emails: ['a@example.com'],
+            dryRun: true,
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertStringContainsString('role_not_allowed', $result['errors'][0]);
+    }
+}


### PR DESCRIPTION
## Summary
- New copilot write action `user_role_add`: grant a role (e.g. "leading teacher") to one or many users by email.
- Role-request parser handles a labelled block or a pasted table (Country / Name / Email / add / role / date).
- Dry-run preview lists each account (will be added / already has / not found / needs manual check); APPROVE applies it.
- Plain-language dry-run and completion emails (batch summary).
- Any existing role allowed; optionally restrict via `SUPPORT_GMAIL_ROLE_ADD_ALLOWED_ROLES`.

## Test plan
- [x] `php artisan test tests/Unit/Support` (role parser, service, dry-run/completion copy)
- [ ] After deploy: send a `codeweek-support` email with the pasted list, verify dry-run, reply APPROVE, check completion summary.

Made with [Cursor](https://cursor.com)