### PR TITLE
Support copilot: add user_email_update

### DIFF
--- a/app/Jobs/Support/ExecuteApprovedSupportActionJob.php
+++ b/app/Jobs/Support/ExecuteApprovedSupportActionJob.php
@@ -11,6 +11,7 @@ use App\Services\Support\SupportActionLogger;
 use App\Services\Support\SupportApprovalEmailService;
 use App\Services\Support\UserProfileUpdateService;
 use App\Services\Support\UserRestoreService;
+use App\Services\Support\UserEmailUpdateService;
 use App\Services\Support\UserRoleAddService;
 use App\Services\Support\UserRoleRemoveService;
 use Illuminate\Bus\Queueable;
@@ -37,6 +38,7 @@ class ExecuteApprovedSupportActionJob implements ShouldQueue
         ContentUpdateService $contentUpdate,
         UserRoleAddService $userRoleAdd,
         UserRoleRemoveService $userRoleRemove,
+        UserEmailUpdateService $userEmailUpdate,
     ): void
     {
         $approval = SupportApproval::findOrFail($this->supportApprovalId);
@@ -96,6 +98,8 @@ class ExecuteApprovedSupportActionJob implements ShouldQueue
             $result = $userRoleAdd->addFromCase($case, dryRun: false, viaEmailApproval: true);
         } elseif ($action === 'user_role_remove') {
             $result = $userRoleRemove->removeFromCase($case, dryRun: false, viaEmailApproval: true);
+        } elseif ($action === 'user_email_update') {
+            $result = $userEmailUpdate->updateFromCase($case, dryRun: false, viaEmailApproval: true);
         } elseif ($action === 'code_change') {
             $result = $cursorAgent->launchCodeAgent(
                 prompt: (string) ($payload['cursor_prompt'] ?? ''),

--- a/app/Jobs/Support/ProcessSupportCaseDiagnosticsJob.php
+++ b/app/Jobs/Support/ProcessSupportCaseDiagnosticsJob.php
@@ -12,6 +12,7 @@ use App\Services\Support\SupportJson;
 use App\Services\Support\UserProfileUpdateService;
 use App\Services\Support\UserRestoreService;
 use App\Services\Support\UserRoleAddService;
+use App\Services\Support\UserEmailUpdateService;
 use App\Services\Support\UserRoleRemoveService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -34,6 +35,7 @@ class ProcessSupportCaseDiagnosticsJob implements ShouldQueue
         UserProfileUpdateService $userProfileUpdate,
         UserRoleAddService $userRoleAdd,
         UserRoleRemoveService $userRoleRemove,
+        UserEmailUpdateService $userEmailUpdate,
         ArtisanCommandRunner $artisanRunner,
         ContentUpdateService $contentUpdate,
     ): void {
@@ -74,6 +76,20 @@ class ProcessSupportCaseDiagnosticsJob implements ShouldQueue
                 actionName: 'user_profile_update',
                 actionType: 'write',
                 input: ['email' => $case->target_email, 'dry_run' => true],
+                output: $dryRunResult,
+                succeeded: (bool) ($dryRunResult['ok'] ?? false),
+                executedBy: 'agent',
+                correlationId: $case->correlation_id,
+            );
+        }
+
+        if ($case->case_type === 'email_change') {
+            $dryRunResult = $userEmailUpdate->updateFromCase($case, dryRun: true);
+            $logger->log(
+                case: $case,
+                actionName: 'user_email_update',
+                actionType: 'write',
+                input: ['dry_run' => true],
                 output: $dryRunResult,
                 succeeded: (bool) ($dryRunResult['ok'] ?? false),
                 executedBy: 'agent',

--- a/app/Services/Support/Agents/CursorCliTriageProvider.php
+++ b/app/Services/Support/Agents/CursorCliTriageProvider.php
@@ -29,6 +29,7 @@ class CursorCliTriageProvider implements TriageProvider
         'role_issue',
         'role_add',
         'role_remove',
+        'email_change',
         'code_change',
         'artisan_command',
         'content_update',
@@ -142,6 +143,8 @@ to "add". Include EVERY email listed in the request (one per person), even for l
 Use "role_remove" when the request is to remove/revoke/delete a role (e.g. "ambassador") from one
 or more users. Use the same target_email/secondary_emails and role_name fields, and set
 "role_operation" to "remove".
+Use "email_change" when the request is to change/update a user's login email address. Put the
+current account email in target_email/current_email and the requested new email in new_email.
 {$artisanBlock}{$contentBlock}
 JSON schema to return:
 {
@@ -157,6 +160,8 @@ JSON schema to return:
   "profile_lastname": "<requested last name or null>",
   "role_name": "<for role_add/role_remove: the role affected, else null>",
   "role_operation": "<for role_add: add; for role_remove: remove; else null>",
+  "current_email": "<for email_change: the account email today, else null>",
+  "new_email": "<for email_change: the requested new email, else null>",
   "change_summary": "<for code_change: one sentence describing the fix, else null>",
   "change_area": "<for code_change: e.g. frontend/blade/css/js, else null>",
   "cursor_prompt": "<for code_change: a precise instruction for a coding agent to implement the fix and open a PR, else null>",
@@ -301,6 +306,7 @@ BLOCK;
             'account_restore' => 'user_restore',
             'role_add' => 'user_role_add',
             'role_remove' => 'user_role_remove',
+            'email_change' => 'user_email_update',
             'code_change' => 'code_change',
             'artisan_command' => 'artisan_command',
             'content_update' => 'content_update',
@@ -332,6 +338,8 @@ BLOCK;
             'profile_lastname' => $this->stringOrNull($data['profile_lastname'] ?? null),
             'role_name' => $this->stringOrNull($data['role_name'] ?? null),
             'role_operation' => $this->normalizeRoleOperation($data['role_operation'] ?? null),
+            'current_email' => $this->stringOrNull($data['current_email'] ?? null),
+            'new_email' => $this->stringOrNull($data['new_email'] ?? null),
             'risk_level' => $risk,
             'recommended_runbook' => $this->stringOrNull($data['recommended_runbook'] ?? null) ?? $caseType,
             'needs_human_review' => (bool) ($data['needs_human_review'] ?? false),

--- a/app/Services/Support/Agents/TriageAgentService.php
+++ b/app/Services/Support/Agents/TriageAgentService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Support\Agents;
 
 use App\Models\Support\SupportCase;
+use App\Services\Support\SupportEmailChangeRequestParser;
 use App\Services\Support\SupportProfileRequestParser;
 use App\Services\Support\SupportRoleRequestParser;
 use Illuminate\Support\Str;
@@ -11,6 +12,7 @@ class TriageAgentService
 {
     public function __construct(
         private readonly SupportProfileRequestParser $profileParser,
+        private readonly SupportEmailChangeRequestParser $emailChangeParser,
         private readonly CursorCliTriageProvider $aiProvider,
         private readonly SupportRoleRequestParser $roleParser,
     ) {
@@ -58,7 +60,9 @@ class TriageAgentService
         $rawText = (string) ($case->normalized_message ?? $case->raw_message ?? '');
         $text = Str::lower($rawText);
         $profile = $this->profileParser->parse($rawText);
+        $emailChange = $this->emailChangeParser->parse($rawText);
         $roleRequest = $this->roleParser->parse($rawText);
+        $hasEmailChangeRequest = $emailChange['from_email'] !== null && $emailChange['to_email'] !== null;
         $hasRoleAddRequest = $roleRequest['role'] !== null
             && $roleRequest['operation'] === 'add'
             && $roleRequest['emails'] !== [];
@@ -76,6 +80,9 @@ class TriageAgentService
         } elseif ($hasRoleAddRequest) {
             $caseType = 'role_add';
             $runbook = 'add_user_role';
+        } elseif ($hasEmailChangeRequest) {
+            $caseType = 'email_change';
+            $runbook = 'update_user_email';
         } elseif (Str::contains($text, ['soft-deleted', 'deleted', 'restore account', 'account missing'])) {
             $caseType = 'account_restore';
             $runbook = 'restore_deleted_account';
@@ -107,6 +114,9 @@ class TriageAgentService
         if ($hasRoleRequest) {
             $targetEmail = $roleRequest['emails'][0];
             $secondary = array_values(array_slice($roleRequest['emails'], 1));
+        } elseif ($hasEmailChangeRequest) {
+            $targetEmail = $emailChange['from_email'];
+            $secondary = [$emailChange['to_email']];
         } else {
             $targetEmail = $profile['email'] ?? $this->extractFirstEmail($text);
             $secondary = $this->extractAllEmails($text);
@@ -116,6 +126,9 @@ class TriageAgentService
         $risk = Str::contains($text, ['password reset', 'merge', 'ownership', 'privileged']) ? 'high' : 'low';
         if ($caseType === 'profile_update') {
             $risk = 'low';
+        }
+        if ($caseType === 'email_change') {
+            $risk = 'medium';
         }
         if ($hasRoleRequest && $this->roleLooksPrivileged((string) $roleRequest['role'])) {
             $risk = 'high';
@@ -128,6 +141,7 @@ class TriageAgentService
             'profile_update' => 'user_profile_update',
             'role_add' => 'user_role_add',
             'role_remove' => 'user_role_remove',
+            'email_change' => 'user_email_update',
             default => null,
         };
 
@@ -142,6 +156,8 @@ class TriageAgentService
             'profile_lastname' => $profile['lastname'],
             'role_name' => $hasRoleRequest ? $roleRequest['role'] : null,
             'role_operation' => $hasRoleRequest ? $roleRequest['operation'] : null,
+            'current_email' => $hasEmailChangeRequest ? $emailChange['from_email'] : null,
+            'new_email' => $hasEmailChangeRequest ? $emailChange['to_email'] : null,
             'risk_level' => $risk,
             'recommended_runbook' => $runbook,
             'needs_human_review' => $needsHuman,

--- a/app/Services/Support/SupportApprovalEmailService.php
+++ b/app/Services/Support/SupportApprovalEmailService.php
@@ -16,6 +16,7 @@ class SupportApprovalEmailService
         private readonly SupportSenderAllowlist $allowlist,
         private readonly SupportProfileRequestParser $profileParser,
         private readonly SupportRoleRequestResolver $roleResolver,
+        private readonly SupportEmailChangeRequestResolver $emailChangeResolver,
     ) {
     }
 
@@ -24,6 +25,7 @@ class SupportApprovalEmailService
         $prefix = (string) config('support_gmail.approval_subject_prefix', '[CW-SUPPORT');
         $headline = match ($case->case_type) {
             'profile_update' => 'Please review — name change',
+            'email_change' => 'Please review — account email change',
             'account_restore' => 'Please review — account restore',
             'role_add' => 'Please review — add user role',
             'role_remove' => 'Please review — remove user role',
@@ -269,6 +271,19 @@ class SupportApprovalEmailService
             ];
         }
 
+        if ($case->case_type === 'email_change') {
+            $change = $this->emailChangeResolver->resolve($case);
+            if ($change['from_email'] !== null && $change['to_email'] !== null) {
+                return [
+                    'action' => 'user_email_update',
+                    'payload' => [
+                        'from' => $change['from_email'],
+                        'to' => $change['to_email'],
+                    ],
+                ];
+            }
+        }
+
         if ($case->case_type === 'profile_update' && $case->target_email) {
             $profile = $this->profileParser->parse((string) ($case->normalized_message ?? $case->raw_message ?? ''));
             if ($profile['firstname'] !== null || $profile['lastname'] !== null) {
@@ -503,7 +518,11 @@ class SupportApprovalEmailService
     {
         $action = $proposedAction['action'] ?? 'none';
         $payload = $proposedAction['payload'] ?? [];
-        $email = (string) ($case->target_email ?? $payload['email'] ?? '');
+        $email = (string) ($case->target_email ?? $payload['email'] ?? $payload['from'] ?? '');
+
+        if ($action === 'user_email_update') {
+            return $this->dryRunEmailChangeLines($case, $payload);
+        }
 
         if ($action === 'user_profile_update') {
             return $this->dryRunProfileChangeLines($case, $payload, $email);
@@ -538,6 +557,48 @@ class SupportApprovalEmailService
             'We could not determine an automatic change from this email.',
             'Check that the message includes lines like "Requested first name:" and "Requested last name:".',
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return list<string>
+     */
+    private function dryRunEmailChangeLines(SupportCase $case, array $payload): array
+    {
+        $output = $case->actions()
+            ->where('action_name', 'user_email_update')
+            ->where('action_type', 'write')
+            ->latest()
+            ->first()?->output_json;
+
+        $result = is_array($output) ? ($output['result'] ?? []) : [];
+        $from = (string) ($result['before']['email'] ?? $payload['from'] ?? $case->target_email ?? '');
+        $to = (string) ($result['after']['email'] ?? $payload['to'] ?? '');
+        $note = (string) ($result['note'] ?? '');
+
+        if ($note === 'email_already_matches_requested_value') {
+            return [
+                '',
+                'The account already uses '.$to.'.',
+                'Approving will make no change.',
+            ];
+        }
+
+        $lines = [
+            '',
+            'We will update the login email on this CodeWeek account:',
+            '  • From: '.($from !== '' ? $from : '(not found)'),
+            '  • To:   '.($to !== '' ? $to : '(not found)'),
+        ];
+
+        if (($result['would_update_email_display'] ?? false) === true) {
+            $lines[] = '  • The public display email will be updated to match.';
+        }
+
+        $lines[] = '';
+        $lines[] = 'The person will need to verify the new email address before it is fully active.';
+
+        return $lines;
     }
 
     /**
@@ -829,6 +890,7 @@ class SupportApprovalEmailService
 
         return match ($action) {
             'user_profile_update' => 'Done — name updated on CodeWeek account',
+            'user_email_update' => 'Done — account email updated',
             'user_restore' => 'Done — CodeWeek account reactivated',
             'user_role_add' => 'Done — user role added',
             'user_role_remove' => 'Done — user role removed',
@@ -877,7 +939,7 @@ class SupportApprovalEmailService
         }
 
         // Role add/remove are batch actions; the per-account list is shown above.
-        if ($email !== '' && ! in_array($action, ['user_role_add', 'user_role_remove'], true)) {
+        if ($email !== '' && ! in_array($action, ['user_role_add', 'user_role_remove', 'user_email_update'], true)) {
             $lines[] = '';
             $lines[] = 'Account email: '.$email;
         }
@@ -888,10 +950,10 @@ class SupportApprovalEmailService
 
         $lines[] = '';
         if ($succeeded) {
-            $lines[] = in_array($action, ['user_role_add', 'user_role_remove'], true)
+            $lines[] = in_array($action, ['user_role_add', 'user_role_remove', 'user_email_update'], true)
                 ? 'No further action is needed. You do not need to reply to this email.'
                 : 'No further action is needed. The supporter can sign in with their usual email and password.';
-            if (! in_array($action, ['user_role_add', 'user_role_remove'], true)) {
+            if (! in_array($action, ['user_role_add', 'user_role_remove', 'user_email_update'], true)) {
                 $lines[] = 'You do not need to reply to this email.';
             }
         } else {
@@ -913,6 +975,33 @@ class SupportApprovalEmailService
     {
         $inner = is_array($result['result'] ?? null) ? $result['result'] : [];
         $note = is_string($inner['note'] ?? null) ? $inner['note'] : '';
+
+        if ($action === 'user_email_update') {
+            $before = (array) ($inner['before'] ?? []);
+            $after = (array) ($inner['after'] ?? []);
+
+            if ($note === 'email_already_matches_requested_value') {
+                return [
+                    'The account already uses the requested email address — no change was required.',
+                ];
+            }
+
+            $lines = [
+                'We updated the login email on this CodeWeek account.',
+                '',
+                '  • From: '.(string) ($before['email'] ?? '(unknown)'),
+                '  • To:   '.(string) ($after['email'] ?? '(unknown)'),
+            ];
+
+            if (($inner['would_update_email_display'] ?? false) === true) {
+                $lines[] = '  • The public display email was updated to match.';
+            }
+
+            $lines[] = '';
+            $lines[] = 'The person should sign in with the new email address and complete email verification if prompted.';
+
+            return $lines;
+        }
 
         if ($action === 'user_profile_update') {
             $lines = [
@@ -1128,7 +1217,11 @@ class SupportApprovalEmailService
         return match (true) {
             str_contains($code, 'no_matching_user') => 'We could not find a CodeWeek account with that email address.',
             str_contains($code, 'ambiguous_user') => 'More than one account matched this email. A team member must review Case #'.$caseId.' manually.',
-            str_contains($code, 'invalid_email') => 'The email address on the request was not valid.',
+            str_contains($code, 'invalid_from_email') => 'The current email address on the request was not valid.',
+            str_contains($code, 'invalid_to_email') => 'The new email address on the request was not valid.',
+            str_contains($code, 'from_and_to_emails_identical') => 'The current and new email addresses are the same.',
+            str_contains($code, 'to_email_already_in_use') => 'Another CodeWeek account already uses the new email address.',
+            str_contains($code, 'email_already_matches') => 'The account already uses the requested email address.',
             str_contains($code, 'no_profile_fields') => 'The request did not include a first or last name to update.',
             str_contains($code, 'dry_run_mode') => 'The system is in preview-only mode and could not apply live changes.',
             str_contains($code, 'unsupported_approved_action') => 'This type of request cannot be run automatically yet.',

--- a/app/Services/Support/SupportEmailChangeRequestParser.php
+++ b/app/Services/Support/SupportEmailChangeRequestParser.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Services\Support;
+
+use Illuminate\Support\Str;
+
+/**
+ * Extract an email-change request (from → to) from support ticket text.
+ */
+final class SupportEmailChangeRequestParser
+{
+    /**
+     * @return array{from_email: ?string, to_email: ?string}
+     */
+    public function parse(string $text): array
+    {
+        $normalized = Str::of($text)->replace("\r\n", "\n")->toString();
+
+        $from = $this->extractLabeledEmail($normalized, ['current', 'account', 'old', 'from']);
+        $to = $this->extractLabeledEmail($normalized, ['new', 'to', 'updated']);
+
+        if ($from === null) {
+            $from = $this->extractLabeledEmail($normalized, ['email']);
+            if ($to !== null && $from === $to) {
+                $from = null;
+            }
+        }
+
+        $emails = $this->extractAllEmails($normalized);
+        if ($from === null && $to === null && count($emails) >= 2) {
+            $from = $emails[0];
+            $to = $emails[1];
+        } elseif ($from === null && $to !== null) {
+            $from = $this->firstEmailOtherThan($emails, $to);
+        } elseif ($to === null && $from !== null) {
+            $to = $this->firstEmailOtherThan($emails, $from);
+        }
+
+        return [
+            'from_email' => $from,
+            'to_email' => $to,
+        ];
+    }
+
+    /**
+     * @param list<string> $prefixes
+     */
+    private function extractLabeledEmail(string $text, array $prefixes): ?string
+    {
+        foreach ($prefixes as $prefix) {
+            $pattern = '/(?:^|\n)\s*(?:'.preg_quote($prefix, '/').'\s+)?email(?:\s+address)?\s*(?:\(current\)|\(new\))?\s*[:*]\s*([^\n\r]+)/iu';
+            if (preg_match($pattern, $text, $m)) {
+                return $this->firstEmailInString($m[1]);
+            }
+        }
+
+        return null;
+    }
+
+    private function firstEmailInString(string $value): ?string
+    {
+        preg_match('/[a-z0-9._%+\\-]+@[a-z0-9.\\-]+\\.[a-z]{2,}/i', $value, $m);
+
+        return isset($m[0]) ? Str::lower(trim($m[0])) : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractAllEmails(string $text): array
+    {
+        preg_match_all('/[a-z0-9._%+\\-]+@[a-z0-9.\\-]+\\.[a-z]{2,}/i', $text, $m);
+        $emails = array_map(fn ($e) => Str::lower(trim($e)), $m[0] ?? []);
+
+        return array_values(array_unique($emails));
+    }
+
+    /**
+     * @param list<string> $emails
+     */
+    private function firstEmailOtherThan(array $emails, string $other): ?string
+    {
+        $other = Str::lower(trim($other));
+        foreach ($emails as $email) {
+            if ($email !== $other) {
+                return $email;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Services/Support/SupportEmailChangeRequestResolver.php
+++ b/app/Services/Support/SupportEmailChangeRequestResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Services\Support;
+
+use App\Models\Support\SupportCase;
+
+/**
+ * Resolve the email-change request for a case (AI-first, parser fallback).
+ */
+class SupportEmailChangeRequestResolver
+{
+    public function __construct(
+        private readonly SupportEmailChangeRequestParser $parser,
+    ) {
+    }
+
+    /**
+     * @return array{from_email: ?string, to_email: ?string, source: array{mode: string}}
+     */
+    public function resolve(SupportCase $case): array
+    {
+        return $this->aiEnabled()
+            ? $this->resolveFromTriage($case)
+            : $this->resolveFromParser($case);
+    }
+
+    /**
+     * @return array{from_email: ?string, to_email: ?string, source: array{mode: string}}
+     */
+    private function resolveFromTriage(SupportCase $case): array
+    {
+        $triage = $this->triageOutput($case);
+
+        $from = SupportEmailAddress::normalize((string) ($case->target_email ?: ($triage['current_email'] ?? '')));
+        $to = SupportEmailAddress::normalize((string) ($triage['new_email'] ?? ''));
+
+        return [
+            'from_email' => $from,
+            'to_email' => $to,
+            'source' => ['mode' => 'ai'],
+        ];
+    }
+
+    /**
+     * @return array{from_email: ?string, to_email: ?string, source: array{mode: string}}
+     */
+    private function resolveFromParser(SupportCase $case): array
+    {
+        $parsed = $this->parser->parse((string) ($case->normalized_message ?? $case->raw_message ?? ''));
+
+        return [
+            'from_email' => $parsed['from_email'],
+            'to_email' => $parsed['to_email'],
+            'source' => ['mode' => 'deterministic'],
+        ];
+    }
+
+    private function aiEnabled(): bool
+    {
+        return (bool) config('support_ai.enabled', false)
+            && (bool) config('support_ai.triage.enabled', true);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function triageOutput(SupportCase $case): array
+    {
+        $output = $case->actions()
+            ->where('action_name', 'triage')
+            ->latest()
+            ->first()?->output_json;
+
+        return is_array($output) ? $output : [];
+    }
+}

--- a/app/Services/Support/UserEmailUpdateService.php
+++ b/app/Services/Support/UserEmailUpdateService.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Services\Support;
+
+use App\Models\Support\SupportCase;
+use App\User;
+use Illuminate\Support\Facades\DB;
+
+class UserEmailUpdateService
+{
+    public function __construct(
+        private readonly SupportEmailChangeRequestResolver $resolver,
+    ) {
+    }
+
+    public function updateFromCase(SupportCase $case, bool $dryRun, bool $viaEmailApproval = false): array
+    {
+        $resolved = $this->resolver->resolve($case);
+
+        return $this->updateEmail(
+            case: $case,
+            fromEmail: (string) ($resolved['from_email'] ?? ''),
+            toEmail: (string) ($resolved['to_email'] ?? ''),
+            dryRun: $dryRun,
+            viaEmailApproval: $viaEmailApproval,
+        );
+    }
+
+    public function updateEmail(
+        SupportCase $case,
+        string $fromEmail,
+        string $toEmail,
+        bool $dryRun,
+        bool $viaEmailApproval = false,
+    ): array {
+        $tool = 'user_email_update';
+        $from = SupportEmailAddress::normalize($fromEmail) ?? '';
+        $to = SupportEmailAddress::normalize($toEmail) ?? '';
+        $input = [
+            'from' => $from,
+            'to' => $to,
+            'dry_run' => $dryRun,
+        ];
+
+        if (! $this->isValidEmail($from)) {
+            return SupportJson::fail($tool, $input, 'invalid_from_email');
+        }
+        if (! $this->isValidEmail($to)) {
+            return SupportJson::fail($tool, $input, 'invalid_to_email');
+        }
+        if ($from === $to) {
+            return SupportJson::fail($tool, $input, 'from_and_to_emails_identical');
+        }
+
+        $matches = User::withTrashed()
+            ->whereRaw('LOWER(email) = ?', [$from])
+            ->orWhereRaw('LOWER(email_display) = ?', [$from])
+            ->get();
+
+        if ($matches->isEmpty()) {
+            return SupportJson::fail($tool, $input, 'no_matching_user_found');
+        }
+
+        if ($matches->count() > 1) {
+            return SupportJson::fail($tool, $input, [
+                'ambiguous_user_match',
+                'matched_user_ids: '.$matches->pluck('id')->implode(','),
+            ]);
+        }
+
+        /** @var User $user */
+        $user = $matches->first();
+
+        $conflict = User::withTrashed()
+            ->where('id', '<>', $user->id)
+            ->where(function ($q) use ($to) {
+                $q->whereRaw('LOWER(email) = ?', [$to])
+                    ->orWhereRaw('LOWER(email_display) = ?', [$to]);
+            })
+            ->exists();
+
+        if ($conflict) {
+            return SupportJson::fail($tool, $input, 'to_email_already_in_use');
+        }
+
+        $wouldUpdateEmailDisplay = SupportEmailAddress::normalize((string) ($user->email_display ?? '')) === $from;
+
+        $before = [
+            'user_id' => $user->id,
+            'email' => $user->email,
+            'email_display' => $user->email_display,
+            'email_verified_at' => optional($user->email_verified_at)->toISOString(),
+        ];
+
+        if (SupportEmailAddress::normalize((string) $user->email) === $to
+            && (! $wouldUpdateEmailDisplay || SupportEmailAddress::normalize((string) ($user->email_display ?? '')) === $to)) {
+            return SupportJson::ok($tool, $input, [
+                'dry_run' => $dryRun,
+                'before' => $before,
+                'after' => $before,
+                'would_update_email_display' => false,
+                'note' => 'email_already_matches_requested_value',
+            ]);
+        }
+
+        $after = [
+            'user_id' => $user->id,
+            'email' => $to,
+            'email_display' => $wouldUpdateEmailDisplay ? $to : $user->email_display,
+            'email_verified_at' => null,
+        ];
+
+        if ($dryRun) {
+            return SupportJson::ok($tool, $input, [
+                'dry_run' => true,
+                'before' => $before,
+                'after' => $after,
+                'would_update_email_display' => $wouldUpdateEmailDisplay,
+            ]);
+        }
+
+        if (config('support_gmail.dry_run') && ! $viaEmailApproval) {
+            return SupportJson::fail($tool, $input, 'dry_run_mode_requires_email_approval');
+        }
+
+        DB::transaction(function () use ($user, $to, $wouldUpdateEmailDisplay) {
+            $user->email = $to;
+            if ($wouldUpdateEmailDisplay) {
+                $user->email_display = $to;
+            }
+            if (property_exists($user, 'email_verified_at')) {
+                $user->email_verified_at = null;
+            }
+            $user->save();
+        });
+
+        $user->refresh();
+
+        return SupportJson::ok($tool, $input, [
+            'dry_run' => false,
+            'before' => $before,
+            'after' => [
+                'user_id' => $user->id,
+                'email' => $user->email,
+                'email_display' => $user->email_display,
+                'email_verified_at' => optional($user->email_verified_at)->toISOString(),
+            ],
+            'would_update_email_display' => $wouldUpdateEmailDisplay,
+        ]);
+    }
+
+    private function isValidEmail(string $email): bool
+    {
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+}

--- a/config/support_gmail.php
+++ b/config/support_gmail.php
@@ -79,6 +79,7 @@ return [
         'user_profile_update',
         'user_role_add',
         'user_role_remove',
+        'user_email_update',
         'code_change',
         'artisan_command',
         'content_update',

--- a/tests/Unit/Support/SupportApprovalCompletionEmailTest.php
+++ b/tests/Unit/Support/SupportApprovalCompletionEmailTest.php
@@ -67,6 +67,7 @@ final class SupportApprovalCompletionEmailTest extends TestCase
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
             app(\App\Services\Support\SupportRoleRequestResolver::class),
+            app(\App\Services\Support\SupportEmailChangeRequestResolver::class),
         );
 
         $payload = $svc->sendActionCompletion(

--- a/tests/Unit/Support/SupportCompletionEmailCopyTest.php
+++ b/tests/Unit/Support/SupportCompletionEmailCopyTest.php
@@ -57,6 +57,7 @@ final class SupportCompletionEmailCopyTest extends TestCase
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
             app(\App\Services\Support\SupportRoleRequestResolver::class),
+            app(\App\Services\Support\SupportEmailChangeRequestResolver::class),
         );
 
         $svc->sendActionCompletion(
@@ -126,6 +127,7 @@ final class SupportCompletionEmailCopyTest extends TestCase
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
             app(\App\Services\Support\SupportRoleRequestResolver::class),
+            app(\App\Services\Support\SupportEmailChangeRequestResolver::class),
         );
 
         $svc->sendActionCompletion(

--- a/tests/Unit/Support/SupportDryRunEmailCopyTest.php
+++ b/tests/Unit/Support/SupportDryRunEmailCopyTest.php
@@ -71,6 +71,7 @@ final class SupportDryRunEmailCopyTest extends TestCase
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
             app(\App\Services\Support\SupportRoleRequestResolver::class),
+            app(\App\Services\Support\SupportEmailChangeRequestResolver::class),
         );
 
         $svc->sendDryRunReview($case, 'admin@matrixinternet.ie');
@@ -145,6 +146,7 @@ final class SupportDryRunEmailCopyTest extends TestCase
             app(SupportSenderAllowlist::class),
             app(SupportProfileRequestParser::class),
             app(\App\Services\Support\SupportRoleRequestResolver::class),
+            app(\App\Services\Support\SupportEmailChangeRequestResolver::class),
         );
 
         $svc->sendDryRunReview($case, 'admin@matrixinternet.ie');

--- a/tests/Unit/Support/SupportEmailChangeRequestParserTest.php
+++ b/tests/Unit/Support/SupportEmailChangeRequestParserTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Services\Support\SupportEmailChangeRequestParser;
+use Tests\TestCase;
+
+final class SupportEmailChangeRequestParserTest extends TestCase
+{
+    public function test_parses_labelled_email_change_request(): void
+    {
+        $text = <<<'TEXT'
+        Please change the email address for this CodeWeek account.
+
+        Account email (current): anu.kahri@opetus.espoo.fi
+        New email: anu.kahri@gmail.com
+
+        The name should stay the same.
+        TEXT;
+
+        $parsed = (new SupportEmailChangeRequestParser())->parse($text);
+
+        $this->assertSame('anu.kahri@opetus.espoo.fi', $parsed['from_email']);
+        $this->assertSame('anu.kahri@gmail.com', $parsed['to_email']);
+    }
+}

--- a/tests/Unit/Support/UserEmailUpdateServiceTest.php
+++ b/tests/Unit/Support/UserEmailUpdateServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Models\Support\SupportCase;
+use App\Services\Support\UserEmailUpdateService;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class UserEmailUpdateServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeCase(): SupportCase
+    {
+        return SupportCase::create([
+            'source_channel' => 'manual',
+            'processing_mode' => 'manual',
+            'subject' => 'codeweek-support — update account email',
+            'raw_message' => 'test',
+            'status' => 'investigating',
+            'risk_level' => 'medium',
+            'correlation_id' => 'cid',
+        ]);
+    }
+
+    public function test_dry_run_plans_email_change_without_applying(): void
+    {
+        $user = User::factory()->create(['email' => 'old@example.com', 'email_display' => 'old@example.com']);
+
+        $result = app(UserEmailUpdateService::class)->updateEmail(
+            case: $this->makeCase(),
+            fromEmail: 'old@example.com',
+            toEmail: 'new@example.com',
+            dryRun: true,
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('new@example.com', $result['result']['after']['email']);
+        $this->assertTrue($result['result']['would_update_email_display']);
+        $this->assertSame('old@example.com', $user->fresh()->email);
+    }
+
+    public function test_apply_updates_email_with_email_approval(): void
+    {
+        config(['support_gmail.dry_run' => true]);
+        $user = User::factory()->create(['email' => 'old@example.com', 'email_display' => 'old@example.com']);
+
+        $result = app(UserEmailUpdateService::class)->updateEmail(
+            case: $this->makeCase(),
+            fromEmail: 'old@example.com',
+            toEmail: 'new@example.com',
+            dryRun: false,
+            viaEmailApproval: true,
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('new@example.com', $user->fresh()->email);
+        $this->assertSame('new@example.com', $user->fresh()->email_display);
+    }
+
+    public function test_rejects_when_target_email_already_in_use(): void
+    {
+        User::factory()->create(['email' => 'old@example.com']);
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $result = app(UserEmailUpdateService::class)->updateEmail(
+            case: $this->makeCase(),
+            fromEmail: 'old@example.com',
+            toEmail: 'taken@example.com',
+            dryRun: true,
+        );
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('to_email_already_in_use', $result['errors']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `user_email_update` so account email changes work end-to-end (triage → dry-run → APPROVE → execution).
- Fixes Case #178-style misclassification as profile/name change when the request is really an email update.
- Reuses the same safety rules as `support:user-update-email` (ambiguous match refusal, target-email conflict check, optional display-email sync, clears verification).

## Test plan
- [x] `SupportEmailChangeRequestParserTest` — Anu-style labelled request
- [x] `UserEmailUpdateServiceTest` — dry-run, apply, conflict rejection
- [x] existing approval/completion/dry-run copy suites

Made with [Cursor](https://cursor.com)