### PR TITLE
Add admin bulk user changes upload

### DIFF
--- a/app/Http/Controllers/BulkUserChangesController.php
+++ b/app/Http/Controllers/BulkUserChangesController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\BulkUserChanges\BulkUserChangesPlanner;
+use App\Services\BulkUserChanges\BulkUserChangesSheetReader;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class BulkUserChangesController extends Controller
+{
+    private const SESSION_TOKEN = 'bulk_user_changes_token';
+
+    public function index(): View
+    {
+        return view('admin.bulk-user-changes.index');
+    }
+
+    public function validateUpload(
+        Request $request,
+        BulkUserChangesSheetReader $reader,
+        BulkUserChangesPlanner $planner,
+    ): RedirectResponse {
+        $validated = $request->validate([
+            'file' => [
+                'required',
+                'file',
+                'max:10240',
+                function ($attribute, $value, $fail) {
+                    if (! $value) {
+                        return;
+                    }
+                    $ext = strtolower($value->getClientOriginalExtension());
+                    if (! in_array($ext, ['csv', 'xlsx', 'xls'], true)) {
+                        $fail('The file must be a CSV or Excel file (.csv, .xlsx, or .xls).');
+                    }
+                },
+            ],
+        ], [
+            'file.required' => 'Please select a file to upload.',
+        ]);
+
+        $file = $validated['file'];
+        $extension = strtolower($file->getClientOriginalExtension() ?: 'xlsx');
+        $tempDisk = config('filesystems.bulk_upload_temp_disk', 'local');
+        $path = $file->storeAs('temp', 'bulk_user_changes_'.time().'.'.$extension, $tempDisk);
+
+        try {
+            $parsed = $reader->read($path, $tempDisk);
+        } catch (\Throwable $e) {
+            Storage::disk($tempDisk)->delete($path);
+
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'Could not read file: '.$e->getMessage()]);
+        }
+
+        if ($parsed['rows'] === []) {
+            Storage::disk($tempDisk)->delete($path);
+
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'No actionable rows found after the header row. Check that the Changes sheet has email addresses and actions.']);
+        }
+
+        $plan = $planner->plan($parsed['rows']);
+        $token = Str::random(64);
+
+        Cache::put('bulk_user_changes_'.$token, [
+            'path' => $path,
+            'disk' => $tempDisk,
+            'parsed' => $parsed,
+            'plan' => $plan,
+        ], now()->addHours(2));
+
+        $request->session()->put(self::SESSION_TOKEN, $token);
+
+        return redirect()->route('admin.bulk-user-changes.preview');
+    }
+
+    public function preview(Request $request): View|RedirectResponse
+    {
+        $payload = $this->payloadFromSession($request);
+        if ($payload === null) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'No validated upload found. Please upload a file first.']);
+        }
+
+        return view('admin.bulk-user-changes.preview', [
+            'parsed' => $payload['parsed'],
+            'plan' => $payload['plan'],
+            'token' => $request->session()->get(self::SESSION_TOKEN),
+        ]);
+    }
+
+    public function apply(
+        Request $request,
+        BulkUserChangesSheetReader $reader,
+        BulkUserChangesPlanner $planner,
+    ): RedirectResponse {
+        $token = (string) $request->input('token', $request->session()->get(self::SESSION_TOKEN, ''));
+        $payload = $token !== '' ? Cache::get('bulk_user_changes_'.$token) : null;
+
+        if (! is_array($payload)) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'Upload session expired. Please upload the file again.']);
+        }
+
+        $path = (string) ($payload['path'] ?? '');
+        $disk = (string) ($payload['disk'] ?? 'local');
+
+        if ($path === '' || ! Storage::disk($disk)->exists($path)) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'Uploaded file no longer available. Please upload again.']);
+        }
+
+        try {
+            $parsed = $reader->read($path, $disk);
+            $result = $planner->apply($parsed['rows']);
+        } catch (\Throwable $e) {
+            return redirect()->route('admin.bulk-user-changes.preview')
+                ->withErrors(['apply' => 'Apply failed: '.$e->getMessage()]);
+        }
+
+        Storage::disk($disk)->delete($path);
+        Cache::forget('bulk_user_changes_'.$token);
+        $request->session()->forget(self::SESSION_TOKEN);
+        $request->session()->put('bulk_user_changes_report', [
+            'parsed' => $parsed,
+            'result' => $result,
+        ]);
+
+        return redirect()->route('admin.bulk-user-changes.report');
+    }
+
+    public function report(Request $request): View|RedirectResponse
+    {
+        $report = $request->session()->get('bulk_user_changes_report');
+        if (! is_array($report)) {
+            return redirect()->route('admin.bulk-user-changes.index');
+        }
+
+        return view('admin.bulk-user-changes.report', [
+            'parsed' => $report['parsed'],
+            'result' => $report['result'],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function payloadFromSession(Request $request): ?array
+    {
+        $token = (string) $request->session()->get(self::SESSION_TOKEN, '');
+        if ($token === '') {
+            return null;
+        }
+
+        $payload = Cache::get('bulk_user_changes_'.$token);
+
+        return is_array($payload) ? $payload : null;
+    }
+}

--- a/app/Services/BulkUserChanges/BulkUserChangesCountryResolver.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesCountryResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\BulkUserChanges;
+
+use App\Country;
+
+final class BulkUserChangesCountryResolver
+{
+    public function resolveIso(?string $countryName): ?string
+    {
+        if ($countryName === null || trim($countryName) === '' || trim($countryName) === '#VALUE!') {
+            return null;
+        }
+
+        $trimmedName = trim($countryName);
+        $lowerName = mb_strtolower($trimmedName);
+
+        if (strlen($trimmedName) === 2) {
+            $iso = strtoupper($trimmedName);
+            if (Country::query()->where('iso', $iso)->exists()) {
+                return $iso;
+            }
+        }
+
+        $country = Country::query()->where('name', $trimmedName)->first()
+            ?? Country::query()->whereRaw('LOWER(TRIM(name)) = ?', [$lowerName])->first()
+            ?? Country::query()->whereRaw('LOWER(TRIM(name)) LIKE ?', ['%'.$lowerName.'%'])->first();
+
+        return $country?->iso;
+    }
+}

--- a/app/Services/BulkUserChanges/BulkUserChangesPlanner.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesPlanner.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Services\BulkUserChanges;
+
+use App\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+
+final class BulkUserChangesPlanner
+{
+    public function __construct(
+        private readonly BulkUserChangesCountryResolver $countries,
+    ) {
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    public function plan(array $rows): BulkUserChangesResult
+    {
+        $result = new BulkUserChangesResult;
+
+        foreach ($rows as $row) {
+            $result->addRow($this->planRow($row, dryRun: true));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $rows
+     */
+    public function apply(array $rows): BulkUserChangesResult
+    {
+        $result = new BulkUserChangesResult;
+
+        foreach ($rows as $row) {
+            $result->addRow($this->planRow($row, dryRun: false));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function planRow(array $row, bool $dryRun): array
+    {
+        $base = [
+            'row_number' => (int) ($row['row_number'] ?? 0),
+            'country' => $row['country'] ?? null,
+            'full_name' => $row['full_name'] ?? null,
+            'email' => $row['email'] ?? null,
+            'action' => $row['action'] ?? null,
+            'role' => $row['role'] ?? null,
+            'operation' => $row['operation'] ?? null,
+            'planned_changes' => [],
+            'messages' => [],
+        ];
+
+        $operation = (string) ($row['operation'] ?? '');
+
+        if ($operation === '' || $operation === 'manual_review') {
+            return $base + [
+                'bucket' => 'skipped_manual_review',
+                'status' => 'skipped',
+                'message' => 'Needs manual review (unrecognised or unsupported action).',
+            ];
+        }
+
+        $email = (string) ($row['email'] ?? '');
+        if ($email === '') {
+            return $base + [
+                'bucket' => 'skipped_no_email',
+                'status' => 'skipped',
+                'message' => 'No email address on this row.',
+            ];
+        }
+
+        $targetCountryIso = $this->countries->resolveIso($row['country'] ?? null);
+        if (($row['country'] ?? null) && $targetCountryIso === null) {
+            return $base + [
+                'bucket' => 'skipped_unknown_country',
+                'status' => 'skipped',
+                'message' => 'Could not match country "'.($row['country'] ?? '').'" to a CodeWeek country.',
+            ];
+        }
+
+        $matches = $this->findUsersByEmail($email);
+        if ($matches->isEmpty()) {
+            return $base + [
+                'bucket' => 'skipped_user_not_found',
+                'status' => 'skipped',
+                'message' => 'No CodeWeek account found for '.$email.' (users are never created automatically).',
+            ];
+        }
+
+        if ($matches->count() > 1) {
+            return $base + [
+                'bucket' => 'skipped_ambiguous',
+                'status' => 'skipped',
+                'message' => 'Multiple accounts match '.$email.' — needs manual review.',
+                'matched_user_ids' => $matches->pluck('id')->map(fn ($id) => (int) $id)->values()->all(),
+            ];
+        }
+
+        /** @var User $user */
+        $user = $matches->first();
+        $base['user_id'] = (int) $user->id;
+        $changes = [];
+
+        if ($targetCountryIso !== null && (string) $user->country_iso !== (string) $targetCountryIso) {
+            $changes[] = [
+                'type' => 'country_update',
+                'from' => $user->country_iso,
+                'to' => $targetCountryIso,
+            ];
+        }
+
+        if ($operation === 'role_add') {
+            $role = $this->resolveRole((string) ($row['role_name'] ?? ''));
+            if ($role === null) {
+                return $base + [
+                    'bucket' => 'skipped_unknown_role',
+                    'status' => 'skipped',
+                    'message' => 'Unknown role "'.($row['role_name'] ?? '').'".',
+                ];
+            }
+
+            if ($user->hasRole($role->name)) {
+                return $this->finalizeRow($base, $changes, 'skipped_already_has_role', 'skipped', 'Already has role "'.$role->name.'".', $dryRun, $user);
+            }
+
+            $changes[] = ['type' => 'role_add', 'role' => $role->name];
+
+            return $this->finalizeRow($base, $changes, $dryRun ? 'would_apply' : 'applied', $dryRun ? 'planned' : 'applied', $this->describeChanges($changes, $dryRun), $dryRun, $user);
+        }
+
+        if ($operation === 'role_remove') {
+            $role = $this->resolveRole((string) ($row['role_name'] ?? ''));
+            if ($role === null) {
+                return $base + [
+                    'bucket' => 'skipped_unknown_role',
+                    'status' => 'skipped',
+                    'message' => 'Unknown role "'.($row['role_name'] ?? '').'".',
+                ];
+            }
+
+            if (! $user->hasRole($role->name)) {
+                return $this->finalizeRow($base, $changes, 'skipped_no_role', 'skipped', 'Does not have role "'.$role->name.'".', $dryRun, $user);
+            }
+
+            $changes[] = ['type' => 'role_remove', 'role' => $role->name];
+
+            return $this->finalizeRow($base, $changes, $dryRun ? 'would_apply' : 'applied', $dryRun ? 'planned' : 'applied', $this->describeChanges($changes, $dryRun), $dryRun, $user);
+        }
+
+        if ($operation === 'email_update') {
+            $newEmail = (string) ($row['new_email'] ?? '');
+            if ($newEmail === '') {
+                return $base + [
+                    'bucket' => 'skipped_manual_review',
+                    'status' => 'skipped',
+                    'message' => 'Email change requested but no new email could be parsed.',
+                ];
+            }
+
+            if (strcasecmp((string) $user->email, $newEmail) === 0) {
+                return $this->finalizeRow($base, $changes, 'skipped_no_change', 'skipped', 'Account already uses '.$newEmail.'.', $dryRun, $user);
+            }
+
+            if ($this->emailInUseByAnotherUser($newEmail, (int) $user->id)) {
+                return $base + [
+                    'bucket' => 'skipped_email_in_use',
+                    'status' => 'skipped',
+                    'message' => 'New email '.$newEmail.' is already used by another account.',
+                ];
+            }
+
+            $changes[] = [
+                'type' => 'email_update',
+                'from' => $user->email,
+                'to' => $newEmail,
+                'update_display' => strcasecmp((string) ($user->email_display ?? ''), $email) === 0,
+            ];
+
+            return $this->finalizeRow($base, $changes, $dryRun ? 'would_apply' : 'applied', $dryRun ? 'planned' : 'applied', $this->describeChanges($changes, $dryRun), $dryRun, $user);
+        }
+
+        return $base + [
+            'bucket' => 'skipped_manual_review',
+            'status' => 'skipped',
+            'message' => 'Unsupported operation.',
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $changes
+     * @return array<string, mixed>
+     */
+    private function finalizeRow(array $base, array $changes, string $bucket, string $status, string $message, bool $dryRun, User $user): array
+    {
+        if ($changes !== [] && ! $dryRun) {
+            $this->applyChanges($user, $changes);
+        }
+
+        return $base + [
+            'bucket' => $bucket,
+            'status' => $status,
+            'message' => $message,
+            'planned_changes' => $changes,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $changes
+     */
+    private function applyChanges(User $user, array $changes): void
+    {
+        DB::transaction(function () use ($user, $changes) {
+            foreach ($changes as $change) {
+                match ($change['type']) {
+                    'country_update' => $user->update(['country_iso' => $change['to']]),
+                    'role_add' => $user->assignRole((string) $change['role']),
+                    'role_remove' => $user->removeRole((string) $change['role']),
+                    'email_update' => $this->applyEmailUpdate($user, $change),
+                    default => null,
+                };
+            }
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $change
+     */
+    private function applyEmailUpdate(User $user, array $change): void
+    {
+        $user->email = (string) $change['to'];
+        if (($change['update_display'] ?? false) === true) {
+            $user->email_display = (string) $change['to'];
+        }
+        if (property_exists($user, 'email_verified_at')) {
+            $user->email_verified_at = null;
+        }
+        $user->save();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $changes
+     */
+    private function describeChanges(array $changes, bool $dryRun): string
+    {
+        $prefix = $dryRun ? 'Will ' : '';
+        $parts = [];
+
+        foreach ($changes as $change) {
+            $parts[] = match ($change['type']) {
+                'country_update' => $prefix.'set country to '.$change['to'],
+                'role_add' => $prefix.'add role "'.$change['role'].'"',
+                'role_remove' => $prefix.'remove role "'.$change['role'].'"',
+                'email_update' => $prefix.'change email '.$change['from'].' → '.$change['to'],
+                default => $prefix.'update account',
+            };
+        }
+
+        return implode('; ', $parts).'.';
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    private function findUsersByEmail(string $email): Collection
+    {
+        $normalized = strtolower(trim($email));
+
+        return User::query()
+            ->whereRaw('LOWER(email) = ?', [$normalized])
+            ->orWhereRaw('LOWER(email_display) = ?', [$normalized])
+            ->get();
+    }
+
+    private function emailInUseByAnotherUser(string $email, int $exceptUserId): bool
+    {
+        $normalized = strtolower(trim($email));
+
+        return User::withTrashed()
+            ->where('id', '<>', $exceptUserId)
+            ->where(function ($q) use ($normalized) {
+                $q->whereRaw('LOWER(email) = ?', [$normalized])
+                    ->orWhereRaw('LOWER(email_display) = ?', [$normalized]);
+            })
+            ->exists();
+    }
+
+    private function resolveRole(string $roleName): ?Role
+    {
+        if ($roleName === '') {
+            return null;
+        }
+
+        $guard = (string) config('auth.defaults.guard', 'web');
+        $needle = Str::of($roleName)->lower()->replaceMatches('/\s+/', ' ')->trim()->toString();
+        $roles = Role::query()->get();
+
+        $exact = $roles->first(fn (Role $r) => Str::lower($r->name) === $needle && $r->guard_name === $guard)
+            ?? $roles->first(fn (Role $r) => Str::lower($r->name) === $needle);
+
+        if ($exact !== null) {
+            return $exact;
+        }
+
+        $words = explode(' ', $needle);
+        $last = array_pop($words);
+        if ($last !== null) {
+            $words[] = Str::singular($last);
+        }
+        $singular = implode(' ', $words);
+
+        return $roles->first(fn (Role $r) => Str::lower($r->name) === $singular);
+    }
+}

--- a/app/Services/BulkUserChanges/BulkUserChangesResult.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesResult.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\BulkUserChanges;
+
+final class BulkUserChangesResult
+{
+    /** @var list<array<string, mixed>> */
+    public array $rows = [];
+
+    /** @var array<string, int> */
+    public array $summary = [];
+
+    public function addRow(array $row): void
+    {
+        $this->rows[] = $row;
+        $bucket = (string) ($row['bucket'] ?? 'other');
+        $this->summary[$bucket] = ($this->summary[$bucket] ?? 0) + 1;
+    }
+}

--- a/app/Services/BulkUserChanges/BulkUserChangesRowNormalizer.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesRowNormalizer.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Services\BulkUserChanges;
+
+use Illuminate\Support\Str;
+
+final class BulkUserChangesRowNormalizer
+{
+    /**
+     * @param  array<string, mixed>  $raw
+     * @return array{
+     *   country: ?string,
+     *   full_name: ?string,
+     *   email: ?string,
+     *   action: ?string,
+     *   role: ?string,
+     *   comments: ?string,
+     *   operation: ?string,
+     *   role_name: ?string,
+     *   new_email: ?string,
+     * }
+     */
+    public function normalize(array $raw): array
+    {
+        $country = $this->stringOrNull($raw['country'] ?? null);
+        $fullName = $this->stringOrNull($raw['full_name'] ?? null);
+        $email = $this->normalizeEmail($raw['email'] ?? null);
+        $action = $this->normalizeToken($raw['action'] ?? null);
+        $role = $this->stringOrNull($raw['role'] ?? null);
+        $comments = $this->stringOrNull($raw['comments'] ?? null);
+
+        $operation = null;
+        $roleName = null;
+        $newEmail = null;
+
+        if ($email === null && $action === null) {
+            return [
+                'country' => $country,
+                'full_name' => $fullName,
+                'email' => $email,
+                'action' => $action,
+                'role' => $role,
+                'comments' => $comments,
+                'operation' => null,
+                'role_name' => null,
+                'new_email' => null,
+            ];
+        }
+
+        if ($this->looksLikeEmailChange($action, $role)) {
+            $operation = 'email_update';
+            $newEmail = $this->extractEmailFromText((string) $role) ?? $this->extractEmailFromText((string) $comments);
+        } elseif (in_array($action, ['add', 'grant', 'assign'], true)) {
+            $operation = 'role_add';
+            $roleName = $this->normalizeRoleName($role);
+        } elseif (in_array($action, ['delete', 'remove', 'revoke'], true)) {
+            $operation = 'role_remove';
+            $roleName = $this->normalizeRoleName($role);
+        } elseif ($action === 'change') {
+            $operation = 'manual_review';
+        } elseif ($action !== null && $action !== '') {
+            $operation = 'manual_review';
+        }
+
+        if ($operation === 'role_add' || $operation === 'role_remove') {
+            if ($roleName === null || $roleName === '') {
+                $operation = 'manual_review';
+            }
+        }
+
+        if ($operation === 'email_update' && ($newEmail === null || $email === null)) {
+            $operation = 'manual_review';
+        }
+
+        if ($operation === 'role_remove' && ($roleName === null || $roleName === '') && $email !== null) {
+            $operation = 'manual_review';
+        }
+
+        return [
+            'country' => $country,
+            'full_name' => $fullName,
+            'email' => $email,
+            'action' => $action,
+            'role' => $role,
+            'comments' => $comments,
+            'operation' => $operation,
+            'role_name' => $roleName,
+            'new_email' => $newEmail,
+        ];
+    }
+
+    private function looksLikeEmailChange(?string $action, ?string $role): bool
+    {
+        $haystack = mb_strtolower(trim((string) $action.' '.(string) $role));
+
+        return str_contains($haystack, 'email change')
+            || str_contains($haystack, 'e-mail update')
+            || str_contains($haystack, 'email update')
+            || str_contains($haystack, 'new email:');
+    }
+
+    private function normalizeRoleName(?string $role): ?string
+    {
+        if ($role === null) {
+            return null;
+        }
+
+        $role = Str::of($role)->lower()->trim()->toString();
+        if ($role === '') {
+            return null;
+        }
+
+        if (str_contains($role, 'new email:')) {
+            return null;
+        }
+
+        $role = preg_replace('/\b(role|roles)\b/', '', $role) ?? $role;
+        $role = trim(preg_replace('/\s+/', ' ', $role) ?? '');
+
+        return match (true) {
+            str_contains($role, 'leading teacher') => 'leading teacher',
+            str_contains($role, 'ambassador') => 'ambassador',
+            str_contains($role, 'edu coordinator') => 'edu coordinator',
+            default => $role,
+        };
+    }
+
+    private function extractEmailFromText(string $text): ?string
+    {
+        if (preg_match('/[a-z0-9._%+\\-]+@[a-z0-9.\\-]+\\.[a-z]{2,}/i', $text, $m)) {
+            return $this->normalizeEmail($m[0]);
+        }
+
+        return null;
+    }
+
+    private function normalizeEmail(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = strtolower(trim($value, " \t\n\r\0\x0B;"));
+        if ($value === '' || ! filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function normalizeToken(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = strtolower(trim($value));
+        if ($value === '') {
+            return null;
+        }
+
+        if (str_starts_with($value, 'add')) {
+            return 'add';
+        }
+
+        return $value;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Services/BulkUserChanges/BulkUserChangesSheetReader.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesSheetReader.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Services\BulkUserChanges;
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+final class BulkUserChangesSheetReader
+{
+    public function __construct(
+        private readonly BulkUserChangesRowNormalizer $normalizer,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   sheet_name: string,
+     *   header_row: int,
+     *   rows: list<array<string, mixed>>,
+     *   meta: array{total_sheet_rows: int, parsed_rows: int, skipped_blank_rows: int}
+     * }
+     */
+    public function read(string $path, ?string $disk = null): array
+    {
+        $localPath = $path;
+        if ($disk !== null) {
+            $localPath = $this->materializeFromDisk($path, $disk);
+        }
+
+        $spreadsheet = IOFactory::load($localPath);
+        $sheet = $this->resolveChangesSheet($spreadsheet->getSheetNames(), $spreadsheet);
+        $headerRow = $this->detectHeaderRow($sheet);
+        $columnMap = $this->mapColumns($sheet, $headerRow);
+
+        $rows = [];
+        $skippedBlank = 0;
+        $highest = (int) $sheet->getHighestRow();
+
+        for ($rowNumber = $headerRow + 1; $rowNumber <= $highest; $rowNumber++) {
+            $raw = $this->readRow($sheet, $rowNumber, $columnMap);
+            $normalized = $this->normalizer->normalize($raw);
+
+            if ($normalized['email'] === null && $normalized['operation'] === null) {
+                $skippedBlank++;
+
+                continue;
+            }
+
+            $rows[] = [
+                'row_number' => $rowNumber,
+                ...$normalized,
+            ];
+        }
+
+        return [
+            'sheet_name' => $sheet->getTitle(),
+            'header_row' => $headerRow,
+            'rows' => $rows,
+            'meta' => [
+                'total_sheet_rows' => max(0, $highest - $headerRow),
+                'parsed_rows' => count($rows),
+                'skipped_blank_rows' => $skippedBlank,
+            ],
+        ];
+    }
+
+    private function materializeFromDisk(string $path, string $disk): string
+    {
+        $contents = \Illuminate\Support\Facades\Storage::disk($disk)->get($path);
+        $tmp = tempnam(sys_get_temp_dir(), 'bulk_user_changes_');
+        if ($tmp === false) {
+            throw new \RuntimeException('Could not create temp file for bulk user changes upload.');
+        }
+        file_put_contents($tmp, $contents);
+
+        return $tmp;
+    }
+
+  /**
+     * @param  list<string>  $sheetNames
+     */
+    private function resolveChangesSheet(array $sheetNames, \PhpOffice\PhpSpreadsheet\Spreadsheet $spreadsheet): Worksheet
+    {
+        foreach ($sheetNames as $name) {
+            if (strcasecmp(trim($name), 'changes') === 0) {
+                $sheet = $spreadsheet->getSheetByName($name);
+                if ($sheet instanceof Worksheet) {
+                    return $sheet;
+                }
+            }
+        }
+
+        return $spreadsheet->getSheet(0);
+    }
+
+    private function detectHeaderRow(Worksheet $sheet): int
+    {
+        $highest = min((int) $sheet->getHighestRow(), 300);
+
+        for ($row = 1; $row <= $highest; $row++) {
+            $values = array_map(
+                fn ($v) => mb_strtolower(trim((string) $v)),
+                array_values($sheet->rangeToArray('A'.$row.':H'.$row, null, true, true, true)[$row] ?? []),
+            );
+
+            $hasCountry = $this->rowContains($values, 'country');
+            $hasEmail = $this->rowContains($values, 'email');
+            $hasAction = $this->rowContains($values, 'action');
+
+            if ($hasCountry && $hasEmail && $hasAction) {
+                return $row;
+            }
+        }
+
+        return 1;
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function rowContains(array $values, string $needle): bool
+    {
+        foreach ($values as $value) {
+            if ($value !== '' && str_contains($value, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function mapColumns(Worksheet $sheet, int $headerRow): array
+    {
+        $headers = array_values($sheet->rangeToArray('A'.$headerRow.':N'.$headerRow, null, true, true, true)[$headerRow] ?? []);
+        $map = [];
+
+        foreach ($headers as $index => $header) {
+            $key = mb_strtolower(trim((string) $header));
+            if ($key === '') {
+                continue;
+            }
+
+            $column = chr(ord('A') + $index);
+            if ($index >= 26) {
+                continue;
+            }
+
+            if (str_contains($key, 'country')) {
+                $map['country'] = $column;
+            } elseif (str_contains($key, 'full name') || $key === 'name') {
+                $map['full_name'] = $column;
+            } elseif (str_contains($key, 'email')) {
+                $map['email'] = $column;
+            } elseif ($key === 'action') {
+                $map['action'] = $column;
+            } elseif ($key === 'role') {
+                $map['role'] = $column;
+            } elseif (str_contains($key, 'comment')) {
+                $map['comments'] ??= $column;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  array<string, string>  $columnMap
+     * @return array<string, ?string>
+     */
+    private function readRow(Worksheet $sheet, int $rowNumber, array $columnMap): array
+    {
+        $out = [
+            'country' => null,
+            'full_name' => null,
+            'email' => null,
+            'action' => null,
+            'role' => null,
+            'comments' => null,
+        ];
+
+        foreach ($columnMap as $field => $column) {
+            $out[$field] = $this->stringOrNull($sheet->getCell($column.$rowNumber)->getValue());
+        }
+
+        return $out;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/resources/views/admin/bulk-upload/index.blade.php
+++ b/resources/views/admin/bulk-upload/index.blade.php
@@ -4,6 +4,7 @@
     <section id="codeweek-bulk-upload-page" class="codeweek-page">
         <section class="codeweek-content-header" style="display: flex; justify-content: space-between; align-items: center;">
             <h1>Bulk Event Upload</h1>
+            <a href="{{ route('admin.bulk-user-changes.index') }}" class="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Bulk user changes</a>
             <a href="{{ route('admin.resources-import.index') }}" class="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Resources import</a>
         </section>
 

--- a/resources/views/admin/bulk-user-changes/index.blade.php
+++ b/resources/views/admin/bulk-user-changes/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layout.base')
+
+@section('content')
+    <section id="codeweek-bulk-user-changes-page" class="codeweek-page">
+        <section class="codeweek-content-header" style="display: flex; justify-content: space-between; align-items: center;">
+            <h1>Bulk user changes</h1>
+            <a href="{{ route('admin.bulk-upload.index') }}" class="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Bulk event upload</a>
+        </section>
+
+        <section class="codeweek-content-wrapper">
+            <p class="mb-4">Upload the client <strong>Changes</strong> sheet (Excel). The tool finds the header row automatically — rows above current data (e.g. old history) are ignored if they have no email/action. <strong>Missing users are never created.</strong></p>
+
+            @if ($errors->any())
+                <div class="mb-4 p-4 rounded bg-red-50 border border-red-200">
+                    <ul class="list-disc list-inside text-red-700">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('admin.bulk-user-changes.validate') }}" enctype="multipart/form-data" class="codeweek-form">
+                @csrf
+                <div class="codeweek-form-inner-container">
+                    <div class="mb-4">
+                        <label for="bulk-user-changes-file" class="font-medium">Excel file (.xlsx) <span class="text-red-600">*</span></label>
+                        <input type="file" name="file" id="bulk-user-changes-file" accept=".xlsx,.xls,.csv" required
+                               class="mt-2 text-sm file:mr-2 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-primary file:text-white hover:file:opacity-90 file:cursor-pointer cursor-pointer">
+                        <p class="text-sm text-gray-600 mt-2">Uses the sheet named <code>Changes</code>. Required columns: Country, Full name, Email address, ACTION, Role.</p>
+                    </div>
+                    <button type="submit" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-[#20262C] hover:bg-hover-orange duration-300">Upload &amp; preview</button>
+                </div>
+            </form>
+        </section>
+    </section>
+@endsection

--- a/resources/views/admin/bulk-user-changes/preview.blade.php
+++ b/resources/views/admin/bulk-user-changes/preview.blade.php
@@ -1,0 +1,77 @@
+@extends('layout.base')
+
+@php
+    $summary = $plan->summary ?? [];
+    $rows = $plan->rows ?? [];
+    $wouldApply = ($summary['would_apply'] ?? 0);
+    $applied = ($summary['applied'] ?? 0);
+@endphp
+
+@section('content')
+    <section id="codeweek-bulk-user-changes-preview-page" class="codeweek-page">
+        <section class="codeweek-content-header" style="display: flex; justify-content: space-between; align-items: center;">
+            <h1>Bulk user changes — preview</h1>
+            <a href="{{ route('admin.bulk-user-changes.index') }}" class="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Upload another file</a>
+        </section>
+
+        <section class="codeweek-content-wrapper">
+            @if ($errors->any())
+                <div class="mb-4 p-4 rounded bg-red-50 border border-red-200 text-red-700">
+                    @foreach ($errors->all() as $error)
+                        <p>{{ $error }}</p>
+                    @endforeach
+                </div>
+            @endif
+
+            <div class="mb-6 p-4 rounded bg-blue-50 border border-blue-200 text-sm">
+                <p><strong>Sheet:</strong> {{ $parsed['sheet_name'] ?? 'Changes' }} · header row {{ $parsed['header_row'] ?? '?' }}</p>
+                <p><strong>Actionable rows:</strong> {{ $parsed['meta']['parsed_rows'] ?? 0 }} ({{ $parsed['meta']['skipped_blank_rows'] ?? 0 }} blank rows skipped)</p>
+                <p class="mt-2"><strong>Ready to apply:</strong> {{ $summary['would_apply'] ?? 0 }} · <strong>Skipped:</strong> {{ collect($summary)->except(['would_apply', 'applied'])->sum() }}</p>
+            </div>
+
+            @if (($summary['would_apply'] ?? 0) > 0)
+                <form method="POST" action="{{ route('admin.bulk-user-changes.apply') }}" class="mb-6">
+                    @csrf
+                    <input type="hidden" name="token" value="{{ $token }}">
+                    <button type="submit" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-white hover:opacity-90 duration-300"
+                            onclick="return confirm('Apply {{ $summary['would_apply'] }} planned change(s) to live user accounts?');">
+                        Apply {{ $summary['would_apply'] }} change(s)
+                    </button>
+                </form>
+            @endif
+
+            <div class="overflow-x-auto">
+                <table class="w-full border-collapse border border-gray-300 text-sm">
+                    <thead>
+                        <tr class="bg-gray-100">
+                            <th class="border border-gray-300 px-2 py-2 text-left">Row</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Country</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Name</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Email</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Action</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Role</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Result</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($rows as $row)
+                            @php
+                                $status = $row['status'] ?? '';
+                                $isReady = ($row['bucket'] ?? '') === 'would_apply';
+                            @endphp
+                            <tr class="{{ $isReady ? 'bg-green-50' : 'bg-white' }}">
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['row_number'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['country'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['full_name'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['email'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['action'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['role'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['message'] ?? '' }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </section>
+@endsection

--- a/resources/views/admin/bulk-user-changes/report.blade.php
+++ b/resources/views/admin/bulk-user-changes/report.blade.php
@@ -1,0 +1,40 @@
+@extends('layout.base')
+
+@section('content')
+    <section id="codeweek-bulk-user-changes-report-page" class="codeweek-page">
+        <section class="codeweek-content-header" style="display: flex; justify-content: space-between; align-items: center;">
+            <h1>Bulk user changes — report</h1>
+            <a href="{{ route('admin.bulk-user-changes.index') }}" class="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Upload another file</a>
+        </section>
+
+        <section class="codeweek-content-wrapper">
+            <div class="mb-6 p-4 rounded bg-green-50 border border-green-200">
+                <p><strong>Applied:</strong> {{ $result->summary['applied'] ?? 0 }}</p>
+                <p><strong>Skipped / unchanged:</strong> {{ collect($result->summary)->except(['applied'])->sum() }}</p>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="w-full border-collapse border border-gray-300 text-sm">
+                    <thead>
+                        <tr class="bg-gray-100">
+                            <th class="border border-gray-300 px-2 py-2 text-left">Row</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Email</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Status</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">Message</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($result->rows as $row)
+                            <tr class="{{ ($row['bucket'] ?? '') === 'applied' ? 'bg-green-50' : '' }}">
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['row_number'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['email'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['status'] ?? '' }}</td>
+                                <td class="border border-gray-300 px-2 py-2">{{ $row['message'] ?? '' }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\Api;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\BadgesController;
 use App\Http\Controllers\BulkEventUploadController;
+use App\Http\Controllers\BulkUserChangesController;
 use App\Http\Controllers\ResourcesImportController;
 use App\Http\Controllers\CertificateController;
 use App\Http\Controllers\Codeweek4AllController;
@@ -81,6 +82,12 @@ Route::middleware(['auth', 'role:super admin'])->group(function () {
     Route::post('/admin/bulk-upload/import', [BulkEventUploadController::class, 'import'])->name('admin.bulk-upload.import');
     Route::get('/admin/bulk-upload/import', fn () => redirect()->route('admin.bulk-upload.index'))->name('admin.bulk-upload.import.get');
     Route::get('/admin/bulk-upload/report', [BulkEventUploadController::class, 'report'])->name('admin.bulk-upload.report');
+
+    Route::get('/admin/bulk-user-changes', [BulkUserChangesController::class, 'index'])->name('admin.bulk-user-changes.index');
+    Route::post('/admin/bulk-user-changes/validate', [BulkUserChangesController::class, 'validateUpload'])->name('admin.bulk-user-changes.validate');
+    Route::get('/admin/bulk-user-changes/preview', [BulkUserChangesController::class, 'preview'])->name('admin.bulk-user-changes.preview');
+    Route::post('/admin/bulk-user-changes/apply', [BulkUserChangesController::class, 'apply'])->name('admin.bulk-user-changes.apply');
+    Route::get('/admin/bulk-user-changes/report', [BulkUserChangesController::class, 'report'])->name('admin.bulk-user-changes.report');
 
     Route::get('/admin/resources-import', [ResourcesImportController::class, 'index'])->name('admin.resources-import.index');
     Route::post('/admin/resources-import/verify', [ResourcesImportController::class, 'verify'])->name('admin.resources-import.verify');

--- a/tests/Unit/BulkUserChanges/BulkUserChangesPlannerTest.php
+++ b/tests/Unit/BulkUserChanges/BulkUserChangesPlannerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\BulkUserChanges;
+
+use App\Services\BulkUserChanges\BulkUserChangesPlanner;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+final class BulkUserChangesPlannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_plans_role_add_and_country_update_without_creating_user(): void
+    {
+        \App\Country::factory()->create(['iso' => 'BE', 'name' => 'Belgium']);
+        \App\Country::factory()->create(['iso' => 'PL', 'name' => 'Poland']);
+
+        Role::create(['name' => 'leading teacher', 'guard_name' => 'web']);
+        User::factory()->create(['email' => 'teacher@example.com', 'country_iso' => 'BE']);
+
+        $plan = app(BulkUserChangesPlanner::class)->plan([
+            [
+                'row_number' => 10,
+                'country' => 'Poland',
+                'full_name' => 'Test Teacher',
+                'email' => 'teacher@example.com',
+                'action' => 'add',
+                'role' => 'leading teachers',
+                'operation' => 'role_add',
+                'role_name' => 'leading teacher',
+                'new_email' => null,
+            ],
+            [
+                'row_number' => 11,
+                'country' => 'Poland',
+                'full_name' => 'Missing Person',
+                'email' => 'missing@example.com',
+                'action' => 'add',
+                'role' => 'leading teachers',
+                'operation' => 'role_add',
+                'role_name' => 'leading teacher',
+                'new_email' => null,
+            ],
+        ]);
+
+        $this->assertSame(1, $plan->summary['would_apply'] ?? 0);
+        $this->assertSame(1, $plan->summary['skipped_user_not_found'] ?? 0);
+        $this->assertFalse(User::query()->where('email', 'missing@example.com')->exists());
+    }
+}

--- a/tests/Unit/BulkUserChanges/BulkUserChangesRowNormalizerTest.php
+++ b/tests/Unit/BulkUserChanges/BulkUserChangesRowNormalizerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\BulkUserChanges;
+
+use App\Services\BulkUserChanges\BulkUserChangesRowNormalizer;
+use Tests\TestCase;
+
+final class BulkUserChangesRowNormalizerTest extends TestCase
+{
+    public function test_normalizes_add_leading_teacher_row(): void
+    {
+        $normalized = (new BulkUserChangesRowNormalizer())->normalize([
+            'country' => 'Poland',
+            'full_name' => 'Anita Kocunik',
+            'email' => 'anitakocunik@wp.pl;',
+            'action' => 'add ',
+            'role' => 'leading teachers',
+            'comments' => null,
+        ]);
+
+        $this->assertSame('role_add', $normalized['operation']);
+        $this->assertSame('leading teacher', $normalized['role_name']);
+        $this->assertSame('anitakocunik@wp.pl', $normalized['email']);
+    }
+
+    public function test_normalizes_email_change_row(): void
+    {
+        $normalized = (new BulkUserChangesRowNormalizer())->normalize([
+            'country' => 'Finland',
+            'full_name' => 'Anu Kahri',
+            'email' => 'anu.kahri@opetus.espoo.fi',
+            'action' => 'email change',
+            'role' => 'new email: anu.kahri@gmail.com',
+            'comments' => null,
+        ]);
+
+        $this->assertSame('email_update', $normalized['operation']);
+        $this->assertSame('anu.kahri@gmail.com', $normalized['new_email']);
+    }
+
+    public function test_skips_blank_rows(): void
+    {
+        $normalized = (new BulkUserChangesRowNormalizer())->normalize([
+            'country' => null,
+            'full_name' => null,
+            'email' => null,
+            'action' => null,
+            'role' => null,
+            'comments' => null,
+        ]);
+
+        $this->assertNull($normalized['operation']);
+    }
+}

--- a/tests/Unit/BulkUserChanges/BulkUserChangesSheetReaderTest.php
+++ b/tests/Unit/BulkUserChanges/BulkUserChangesSheetReaderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\BulkUserChanges;
+
+use App\Services\BulkUserChanges\BulkUserChangesSheetReader;
+use Tests\TestCase;
+
+final class BulkUserChangesSheetReaderTest extends TestCase
+{
+    public function test_reads_changes_sheet_and_finds_anita_row(): void
+    {
+        $path = base_path('docs/internal/C4EU_20240801_EUCodeWeek ALTEC Contacts_edited for website.xlsx');
+        if (! is_file($path)) {
+            $this->markTestSkipped('Fixture spreadsheet not present.');
+        }
+
+        $parsed = app(BulkUserChangesSheetReader::class)->read($path);
+
+        $this->assertSame('Changes', $parsed['sheet_name']);
+        $this->assertGreaterThan(0, $parsed['header_row']);
+        $this->assertGreaterThan(200, $parsed['meta']['parsed_rows']);
+
+        $anita = collect($parsed['rows'])->first(fn (array $row) => ($row['email'] ?? '') === 'anitakocunik@wp.pl');
+        $this->assertNotNull($anita);
+        $this->assertSame(150, $anita['row_number']);
+        $this->assertSame('role_add', $anita['operation']);
+        $this->assertSame('leading teacher', $anita['role_name']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `/admin/bulk-user-changes` for super admins to upload the client **Changes** spreadsheet (same validate → preview → apply → report flow as bulk event upload).
- Parses role add/remove, email change, and country sync rows; **never creates missing users** — not-found rows appear in the skipped summary.
- **Dynamically detects the header row** on the Changes sheet (no hardcoded row 150); blank rows without email/action are ignored.

## Test plan
- [ ] Log in as super admin → Bulk upload → "Bulk user changes"
- [ ] Upload `C4EU_20240801_EUCodeWeek ALTEC Contacts_edited for website.xlsx` (Changes tab)
- [ ] Preview shows ~172 leading-teacher adds, ambassador removes, email changes; missing users listed as skipped
- [ ] Apply on staging with a small test subset first
- [x] `php artisan test tests/Unit/BulkUserChanges/`

## Notes
- Role swaps (`change ambassador to leading teacher`) → `manual_review` for now
- `edu coordinator` rows skip if that role is not in the DB


Made with [Cursor](https://cursor.com)