### PR TITLE
Require Changes sheet only for bulk user upload

### DIFF
--- a/app/Http/Controllers/BulkUserChangesController.php
+++ b/app/Http/Controllers/BulkUserChangesController.php
@@ -35,8 +35,8 @@ class BulkUserChangesController extends Controller
                         return;
                     }
                     $ext = strtolower($value->getClientOriginalExtension());
-                    if (! in_array($ext, ['csv', 'xlsx', 'xls'], true)) {
-                        $fail('The file must be a CSV or Excel file (.csv, .xlsx, or .xls).');
+                    if (! in_array($ext, ['xlsx', 'xls'], true)) {
+                        $fail('The file must be an Excel workbook (.xlsx or .xls) with a Changes sheet.');
                     }
                 },
             ],

--- a/app/Services/BulkUserChanges/BulkUserChangesSheetReader.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesSheetReader.php
@@ -90,7 +90,12 @@ final class BulkUserChangesSheetReader
             }
         }
 
-        return $spreadsheet->getSheet(0);
+        $available = implode(', ', array_map(fn (string $n) => '"'.$n.'"', $sheetNames));
+
+        throw new \InvalidArgumentException(
+            'No sheet named "Changes" found. Only the Changes tab is read; other sheets are ignored. '
+            .'Sheets in this file: '.($available !== '' ? $available : '(none)').'.'
+        );
     }
 
     private function detectHeaderRow(Worksheet $sheet): int

--- a/resources/views/admin/bulk-user-changes/index.blade.php
+++ b/resources/views/admin/bulk-user-changes/index.blade.php
@@ -8,7 +8,7 @@
         </section>
 
         <section class="codeweek-content-wrapper">
-            <p class="mb-4">Upload the client <strong>Changes</strong> sheet (Excel). The tool finds the header row automatically — rows above current data (e.g. old history) are ignored if they have no email/action. <strong>Missing users are never created.</strong></p>
+            <p class="mb-4">Upload the client Excel workbook. <strong>Only the sheet named <code>Changes</code> is read</strong> — all other tabs are ignored. The tool finds the header row on that sheet automatically; rows with no email/action are skipped. <strong>Missing users are never created.</strong></p>
 
             @if ($errors->any())
                 <div class="mb-4 p-4 rounded bg-red-50 border border-red-200">
@@ -25,9 +25,9 @@
                 <div class="codeweek-form-inner-container">
                     <div class="mb-4">
                         <label for="bulk-user-changes-file" class="font-medium">Excel file (.xlsx) <span class="text-red-600">*</span></label>
-                        <input type="file" name="file" id="bulk-user-changes-file" accept=".xlsx,.xls,.csv" required
+                        <input type="file" name="file" id="bulk-user-changes-file" accept=".xlsx,.xls" required
                                class="mt-2 text-sm file:mr-2 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-primary file:text-white hover:file:opacity-90 file:cursor-pointer cursor-pointer">
-                        <p class="text-sm text-gray-600 mt-2">Uses the sheet named <code>Changes</code>. Required columns: Country, Full name, Email address, ACTION, Role.</p>
+                        <p class="text-sm text-gray-600 mt-2">Must include a tab named <code>Changes</code> (other tabs are not processed). Required columns on that tab: Country, Full name, Email address, ACTION, Role.</p>
                     </div>
                     <button type="submit" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-[#20262C] hover:bg-hover-orange duration-300">Upload &amp; preview</button>
                 </div>

--- a/tests/Unit/BulkUserChanges/BulkUserChangesSheetReaderTest.php
+++ b/tests/Unit/BulkUserChanges/BulkUserChangesSheetReaderTest.php
@@ -26,4 +26,23 @@ final class BulkUserChangesSheetReaderTest extends TestCase
         $this->assertSame('role_add', $anita['operation']);
         $this->assertSame('leading teacher', $anita['role_name']);
     }
+
+    public function test_rejects_workbook_without_changes_sheet(): void
+    {
+        $path = sys_get_temp_dir().'/bulk_user_changes_no_changes_'.uniqid().'.xlsx';
+        $spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet;
+        $spreadsheet->getActiveSheet()->setTitle('Contacts');
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'Country');
+        $writer = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx($spreadsheet);
+        $writer->save($path);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('No sheet named "Changes" found');
+
+            app(BulkUserChangesSheetReader::class)->read($path);
+        } finally {
+            @unlink($path);
+        }
+    }
 }


### PR DESCRIPTION
Stop falling back to the first workbook tab when Changes is missing. Reject uploads without a Changes sheet and drop CSV support so only the intended Excel tab is processed.