### PR TITLE
Add paste-in mode for bulk user changes upload

### DIFF
--- a/app/Http/Controllers/BulkUserChangesController.php
+++ b/app/Http/Controllers/BulkUserChangesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\BulkUserChanges\BulkUserChangesPlanner;
 use App\Services\BulkUserChanges\BulkUserChangesReadOptions;
 use App\Services\BulkUserChanges\BulkUserChangesSheetReader;
+use App\Services\BulkUserChanges\BulkUserChangesTextParser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -22,6 +23,94 @@ class BulkUserChangesController extends Controller
     }
 
     public function validateUpload(
+        Request $request,
+        BulkUserChangesSheetReader $reader,
+        BulkUserChangesTextParser $textParser,
+        BulkUserChangesPlanner $planner,
+    ): RedirectResponse {
+        $hasFile = $request->hasFile('file') && $request->file('file')?->isValid();
+        $hasPaste = trim((string) $request->input('paste', '')) !== '';
+
+        if ($hasFile && $hasPaste) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'Upload a file or paste text, not both.'])
+                ->withInput();
+        }
+
+        if (! $hasFile && ! $hasPaste) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'Upload a file or paste changes to continue.']);
+        }
+
+        if ($hasPaste) {
+            return $this->validatePaste($request, $textParser, $planner);
+        }
+
+        return $this->validateFile($request, $reader, $planner);
+    }
+
+    public function preview(Request $request): View|RedirectResponse
+    {
+        $payload = $this->payloadFromSession($request);
+        if ($payload === null) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'No validated upload found. Please upload a file or paste changes first.']);
+        }
+
+        return view('admin.bulk-user-changes.preview', [
+            'parsed' => $payload['parsed'],
+            'plan' => $payload['plan'],
+            'token' => $request->session()->get(self::SESSION_TOKEN),
+        ]);
+    }
+
+    public function apply(
+        Request $request,
+        BulkUserChangesSheetReader $reader,
+        BulkUserChangesTextParser $textParser,
+        BulkUserChangesPlanner $planner,
+    ): RedirectResponse {
+        $token = (string) $request->input('token', $request->session()->get(self::SESSION_TOKEN, ''));
+        $payload = $token !== '' ? Cache::get('bulk_user_changes_'.$token) : null;
+
+        if (! is_array($payload)) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['file' => 'Session expired. Please upload or paste again.']);
+        }
+
+        try {
+            $parsed = $this->readPayload($payload, $reader, $textParser);
+            $result = $planner->apply($parsed['rows']);
+        } catch (\Throwable $e) {
+            return redirect()->route('admin.bulk-user-changes.preview')
+                ->withErrors(['apply' => 'Apply failed: '.$e->getMessage()]);
+        }
+
+        $this->cleanupPayload($payload);
+        Cache::forget('bulk_user_changes_'.$token);
+        $request->session()->forget(self::SESSION_TOKEN);
+        $request->session()->put('bulk_user_changes_report', [
+            'parsed' => $parsed,
+            'result' => $result,
+        ]);
+
+        return redirect()->route('admin.bulk-user-changes.report');
+    }
+
+    public function report(Request $request): View|RedirectResponse
+    {
+        $report = $request->session()->get('bulk_user_changes_report');
+        if (! is_array($report)) {
+            return redirect()->route('admin.bulk-user-changes.index');
+        }
+
+        return view('admin.bulk-user-changes.report', [
+            'parsed' => $report['parsed'],
+            'result' => $report['result'],
+        ]);
+    }
+
+    private function validateFile(
         Request $request,
         BulkUserChangesSheetReader $reader,
         BulkUserChangesPlanner $planner,
@@ -68,15 +157,56 @@ class BulkUserChangesController extends Controller
                 ->withErrors(['file' => 'No actionable rows found after the header row. Check that the Changes sheet has email addresses and actions.']);
         }
 
+        return $this->storePreviewSession($request, $planner, $parsed, [
+            'source' => 'file',
+            'path' => $path,
+            'disk' => $tempDisk,
+            'ignore_through_row' => $readOptions->ignoreThroughRow,
+        ]);
+    }
+
+    private function validatePaste(
+        Request $request,
+        BulkUserChangesTextParser $textParser,
+        BulkUserChangesPlanner $planner,
+    ): RedirectResponse {
+        $validated = $request->validate([
+            'paste' => ['required', 'string', 'min:10', 'max:100000'],
+        ], [
+            'paste.required' => 'Paste the change list to continue.',
+        ]);
+
+        try {
+            $parsed = $textParser->parse($validated['paste']);
+        } catch (\Throwable $e) {
+            return redirect()->route('admin.bulk-user-changes.index')
+                ->withErrors(['paste' => $e->getMessage()])
+                ->withInput();
+        }
+
+        return $this->storePreviewSession($request, $planner, $parsed, [
+            'source' => 'paste',
+            'paste_text' => $validated['paste'],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $parsed
+     * @param  array<string, mixed>  $cacheMeta
+     */
+    private function storePreviewSession(
+        Request $request,
+        BulkUserChangesPlanner $planner,
+        array $parsed,
+        array $cacheMeta,
+    ): RedirectResponse {
         $plan = $planner->plan($parsed['rows']);
         $token = Str::random(64);
 
         Cache::put('bulk_user_changes_'.$token, [
-            'path' => $path,
-            'disk' => $tempDisk,
+            ...$cacheMeta,
             'parsed' => $parsed,
             'plan' => $plan,
-            'ignore_through_row' => $readOptions->ignoreThroughRow,
         ], now()->addHours(2));
 
         $request->session()->put(self::SESSION_TOKEN, $token);
@@ -84,73 +214,52 @@ class BulkUserChangesController extends Controller
         return redirect()->route('admin.bulk-user-changes.preview');
     }
 
-    public function preview(Request $request): View|RedirectResponse
-    {
-        $payload = $this->payloadFromSession($request);
-        if ($payload === null) {
-            return redirect()->route('admin.bulk-user-changes.index')
-                ->withErrors(['file' => 'No validated upload found. Please upload a file first.']);
-        }
-
-        return view('admin.bulk-user-changes.preview', [
-            'parsed' => $payload['parsed'],
-            'plan' => $payload['plan'],
-            'token' => $request->session()->get(self::SESSION_TOKEN),
-        ]);
-    }
-
-    public function apply(
-        Request $request,
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function readPayload(
+        array $payload,
         BulkUserChangesSheetReader $reader,
-        BulkUserChangesPlanner $planner,
-    ): RedirectResponse {
-        $token = (string) $request->input('token', $request->session()->get(self::SESSION_TOKEN, ''));
-        $payload = $token !== '' ? Cache::get('bulk_user_changes_'.$token) : null;
+        BulkUserChangesTextParser $textParser,
+    ): array {
+        if (($payload['source'] ?? 'file') === 'paste') {
+            $pasteText = (string) ($payload['paste_text'] ?? '');
 
-        if (! is_array($payload)) {
-            return redirect()->route('admin.bulk-user-changes.index')
-                ->withErrors(['file' => 'Upload session expired. Please upload the file again.']);
+            if ($pasteText === '') {
+                throw new \RuntimeException('Pasted text no longer available. Please paste again.');
+            }
+
+            return $textParser->parse($pasteText);
         }
 
         $path = (string) ($payload['path'] ?? '');
         $disk = (string) ($payload['disk'] ?? 'local');
 
         if ($path === '' || ! Storage::disk($disk)->exists($path)) {
-            return redirect()->route('admin.bulk-user-changes.index')
-                ->withErrors(['file' => 'Uploaded file no longer available. Please upload again.']);
+            throw new \RuntimeException('Uploaded file no longer available. Please upload again.');
         }
 
-        try {
-            $readOptions = BulkUserChangesReadOptions::fromInput($payload['ignore_through_row'] ?? null);
-            $parsed = $reader->read($path, $disk, $readOptions);
-            $result = $planner->apply($parsed['rows']);
-        } catch (\Throwable $e) {
-            return redirect()->route('admin.bulk-user-changes.preview')
-                ->withErrors(['apply' => 'Apply failed: '.$e->getMessage()]);
-        }
+        $readOptions = BulkUserChangesReadOptions::fromInput($payload['ignore_through_row'] ?? null);
 
-        Storage::disk($disk)->delete($path);
-        Cache::forget('bulk_user_changes_'.$token);
-        $request->session()->forget(self::SESSION_TOKEN);
-        $request->session()->put('bulk_user_changes_report', [
-            'parsed' => $parsed,
-            'result' => $result,
-        ]);
-
-        return redirect()->route('admin.bulk-user-changes.report');
+        return $reader->read($path, $disk, $readOptions);
     }
 
-    public function report(Request $request): View|RedirectResponse
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function cleanupPayload(array $payload): void
     {
-        $report = $request->session()->get('bulk_user_changes_report');
-        if (! is_array($report)) {
-            return redirect()->route('admin.bulk-user-changes.index');
+        if (($payload['source'] ?? 'file') !== 'file') {
+            return;
         }
 
-        return view('admin.bulk-user-changes.report', [
-            'parsed' => $report['parsed'],
-            'result' => $report['result'],
-        ]);
+        $path = (string) ($payload['path'] ?? '');
+        $disk = (string) ($payload['disk'] ?? 'local');
+
+        if ($path !== '' && Storage::disk($disk)->exists($path)) {
+            Storage::disk($disk)->delete($path);
+        }
     }
 
     /**

--- a/app/Services/BulkUserChanges/BulkUserChangesTextParser.php
+++ b/app/Services/BulkUserChanges/BulkUserChangesTextParser.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Services\BulkUserChanges;
+
+use InvalidArgumentException;
+
+final class BulkUserChangesTextParser
+{
+    private const LINES_PER_RECORD = 5;
+
+    public function __construct(
+        private readonly BulkUserChangesRowNormalizer $normalizer,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *   sheet_name: string,
+     *   header_row: null,
+     *   source: string,
+     *   rows: list<array<string, mixed>>,
+     *   meta: array{
+     *     first_data_row: ?int,
+     *     last_data_row: ?int,
+     *     parsed_rows: int,
+     *     skipped_blank_rows: int,
+     *     skipped_no_email_rows: int,
+     *     skipped_legacy_rows: int,
+     *     skipped_ignored_range_rows: int,
+     *     ignore_through_row: null,
+     *     first_email: ?string,
+     *     last_email: ?string,
+     *   }
+     * }
+     */
+    public function parse(string $text): array
+    {
+        $lines = $this->splitLines($text);
+        if ($lines === []) {
+            throw new InvalidArgumentException('Paste is empty.');
+        }
+
+        if (count($lines) % self::LINES_PER_RECORD !== 0) {
+            throw new InvalidArgumentException(
+                'Paste must be groups of 5 lines (country, name, email, action, role or new email). Found '
+                .count($lines).' non-empty lines.'
+            );
+        }
+
+        $rows = [];
+        $skippedNoEmail = 0;
+        $entryNumber = 1;
+
+        for ($offset = 0; $offset < count($lines); $offset += self::LINES_PER_RECORD) {
+            $raw = $this->rawRecordFromLines(array_slice($lines, $offset, self::LINES_PER_RECORD));
+            $normalized = $this->normalizer->normalize($raw);
+
+            if ($normalized['email'] === null) {
+                $skippedNoEmail++;
+
+                continue;
+            }
+
+            $rows[] = [
+                'row_number' => $entryNumber,
+                ...$normalized,
+            ];
+            $entryNumber++;
+        }
+
+        if ($rows === []) {
+            throw new InvalidArgumentException('No valid email addresses found in pasted text.');
+        }
+
+        $firstRow = $rows[0]['row_number'] ?? null;
+        $lastRow = $rows !== [] ? $rows[array_key_last($rows)]['row_number'] : null;
+
+        return [
+            'sheet_name' => 'Pasted list',
+            'header_row' => null,
+            'source' => 'paste',
+            'rows' => $rows,
+            'meta' => [
+                'first_data_row' => $firstRow,
+                'last_data_row' => $lastRow,
+                'parsed_rows' => count($rows),
+                'skipped_blank_rows' => 0,
+                'skipped_no_email_rows' => $skippedNoEmail,
+                'skipped_legacy_rows' => 0,
+                'skipped_ignored_range_rows' => 0,
+                'ignore_through_row' => null,
+                'first_email' => $rows[0]['email'] ?? null,
+                'last_email' => $rows !== [] ? $rows[array_key_last($rows)]['email'] : null,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitLines(string $text): array
+    {
+        $text = str_replace("\r\n", "\n", $text);
+        $text = str_replace("\r", "\n", $text);
+
+        $lines = [];
+        foreach (explode("\n", $text) as $line) {
+            $line = trim($line);
+            if ($line !== '') {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param  list<string>  $lines
+     * @return array<string, ?string>
+     */
+    private function rawRecordFromLines(array $lines): array
+    {
+        [$country, $fullName, $email, $action, $detail] = $lines;
+        $actionLower = mb_strtolower(trim($action));
+        $detailLower = mb_strtolower(trim($detail));
+
+        $isEmailChange = str_contains($actionLower, 'email change')
+            || str_contains($actionLower, 'email update')
+            || str_contains($detailLower, 'new email');
+
+        return [
+            'country' => $country,
+            'full_name' => $fullName,
+            'email' => $email,
+            'action' => $action,
+            'role' => $isEmailChange ? $detail : $detail,
+            'comments' => $isEmailChange ? $detail : null,
+        ];
+    }
+}

--- a/resources/views/admin/bulk-user-changes/index.blade.php
+++ b/resources/views/admin/bulk-user-changes/index.blade.php
@@ -8,7 +8,7 @@
         </section>
 
         <section class="codeweek-content-wrapper">
-            <p class="mb-4">Upload the client Excel workbook. <strong>Only the sheet named <code>Changes</code> is read</strong> — all other tabs are ignored. If older batches are still on the sheet, set <strong>Ignore rows through</strong> so rows 2 up to that line are skipped (e.g. <code>149</code> to start at row 150). Only rows with an email address are listed. <strong>Missing users are never created.</strong></p>
+            <p class="mb-4">Upload the client Excel workbook or paste a change list below. <strong>Missing users are never created.</strong> You get a preview summary before anything is applied.</p>
 
             @if ($errors->any())
                 <div class="mb-4 p-4 rounded bg-red-50 border border-red-200">
@@ -20,26 +20,48 @@
                 </div>
             @endif
 
-            <form method="POST" action="{{ route('admin.bulk-user-changes.validate') }}" enctype="multipart/form-data" class="codeweek-form">
-                @csrf
-                <div class="codeweek-form-inner-container">
-                    <div class="mb-4">
-                        <label for="bulk-user-changes-file" class="font-medium">Excel file (.xlsx) <span class="text-red-600">*</span></label>
-                        <input type="file" name="file" id="bulk-user-changes-file" accept=".xlsx,.xls" required
-                               class="mt-2 text-sm file:mr-2 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-primary file:text-white hover:file:opacity-90 file:cursor-pointer cursor-pointer">
-                        <p class="text-sm text-gray-600 mt-2">Must include a tab named <code>Changes</code> (other tabs are not processed). Required columns on that tab: Country, Full name, Email address, ACTION, Role.</p>
+            <div class="mb-10">
+                <h2 class="text-lg font-semibold mb-3">Excel upload</h2>
+                <p class="mb-4 text-sm text-gray-700"><strong>Only the sheet named <code>Changes</code> is read.</strong> If older batches are still on the sheet, set <strong>Ignore rows through</strong> (e.g. <code>149</code> to start at row 150).</p>
+
+                <form method="POST" action="{{ route('admin.bulk-user-changes.validate') }}" enctype="multipart/form-data" class="codeweek-form">
+                    @csrf
+                    <div class="codeweek-form-inner-container">
+                        <div class="mb-4">
+                            <label for="bulk-user-changes-file" class="font-medium">Excel file (.xlsx)</label>
+                            <input type="file" name="file" id="bulk-user-changes-file" accept=".xlsx,.xls"
+                                   class="mt-2 text-sm file:mr-2 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-primary file:text-white hover:file:opacity-90 file:cursor-pointer cursor-pointer">
+                        </div>
+                        <div class="mb-4">
+                            <label for="bulk-user-changes-ignore-through-row" class="font-medium">Ignore rows through (optional)</label>
+                            <input type="number" name="ignore_through_row" id="bulk-user-changes-ignore-through-row" min="1" max="10000" step="1"
+                                   value="{{ old('ignore_through_row') }}"
+                                   placeholder="e.g. 149"
+                                   class="mt-2 block w-full max-w-xs rounded border border-gray-300 px-3 py-2 text-sm">
+                            <p class="text-sm text-gray-600 mt-2">Excel row number. Rows 2 through this line are skipped.</p>
+                        </div>
+                        <button type="submit" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-[#20262C] hover:bg-hover-orange duration-300">Upload &amp; preview</button>
                     </div>
-                    <div class="mb-4">
-                        <label for="bulk-user-changes-ignore-through-row" class="font-medium">Ignore rows through (optional)</label>
-                        <input type="number" name="ignore_through_row" id="bulk-user-changes-ignore-through-row" min="1" max="10000" step="1"
-                               value="{{ old('ignore_through_row') }}"
-                               placeholder="e.g. 149"
-                               class="mt-2 block w-full max-w-xs rounded border border-gray-300 px-3 py-2 text-sm">
-                        <p class="text-sm text-gray-600 mt-2">Excel row number. Rows 2 through this line are skipped; processing starts on the next row. Leave blank to read from row 2.</p>
+                </form>
+            </div>
+
+            <div>
+                <h2 class="text-lg font-semibold mb-3">Or paste changes</h2>
+                <p class="mb-4 text-sm text-gray-700">Paste groups of <strong>5 lines per person</strong>: country, full name, email, action, then role (or <code>new email: …</code> for email changes).</p>
+
+                <form method="POST" action="{{ route('admin.bulk-user-changes.validate') }}" class="codeweek-form">
+                    @csrf
+                    <div class="codeweek-form-inner-container">
+                        <div class="mb-4">
+                            <label for="bulk-user-changes-paste" class="font-medium">Change list</label>
+                            <textarea name="paste" id="bulk-user-changes-paste" rows="18"
+                                      placeholder="Poland&#10;Anita Kocunik&#10;anitakocunik@wp.pl&#10;add&#10;leading teachers"
+                                      class="mt-2 block w-full rounded border border-gray-300 px-3 py-2 text-sm font-mono">{{ old('paste') }}</textarea>
+                        </div>
+                        <button type="submit" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-[#20262C] hover:bg-hover-orange duration-300">Paste &amp; preview</button>
                     </div>
-                    <button type="submit" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-[#20262C] hover:bg-hover-orange duration-300">Upload &amp; preview</button>
-                </div>
-            </form>
+                </form>
+            </div>
         </section>
     </section>
 @endsection

--- a/resources/views/admin/bulk-user-changes/preview.blade.php
+++ b/resources/views/admin/bulk-user-changes/preview.blade.php
@@ -29,9 +29,15 @@
                     $firstRow = $meta['first_data_row'] ?? null;
                     $lastRow = $meta['last_data_row'] ?? null;
                     $headerRow = $parsed['header_row'] ?? 1;
+                    $isPaste = ($parsed['source'] ?? '') === 'paste';
+                    $rowLabel = $isPaste ? 'Entry' : 'Row';
                 @endphp
-                <p><strong>Sheet:</strong> {{ $parsed['sheet_name'] ?? 'Changes' }} · header row {{ $headerRow }}</p>
-                <p><strong>Rows in file:</strong>
+                <p><strong>Source:</strong> {{ $parsed['sheet_name'] ?? 'Changes' }}
+                    @if (! $isPaste)
+                        · header row {{ $headerRow }}
+                    @endif
+                </p>
+                <p><strong>{{ $isPaste ? 'Entries' : 'Rows in file' }}:</strong>
                     @if ($firstRow && $lastRow)
                         {{ $firstRow }}–{{ $lastRow }}
                         ({{ $meta['parsed_rows'] ?? 0 }} with email)
@@ -59,7 +65,7 @@
                         @endif
                     </p>
                 @endif
-                @if ($firstRow && $firstRow > $headerRow + 1 && empty($meta['ignore_through_row']))
+                @if ($firstRow && $firstRow > $headerRow + 1 && empty($meta['ignore_through_row']) && ! $isPaste)
                     <p class="mt-2 text-amber-800"><strong>Note:</strong> The first row is {{ $firstRow }}, not row {{ $headerRow + 1 }}. Set <strong>Ignore rows through</strong> on upload, or delete earlier batches in Excel.</p>
                 @endif
                 <p class="mt-2"><strong>Ready to apply:</strong> {{ $summary['would_apply'] ?? 0 }} · <strong>Skipped:</strong> {{ collect($summary)->except(['would_apply', 'applied'])->sum() }}</p>
@@ -80,7 +86,7 @@
                 <table class="w-full border-collapse border border-gray-300 text-sm">
                     <thead>
                         <tr class="bg-gray-100">
-                            <th class="border border-gray-300 px-2 py-2 text-left">Row</th>
+                            <th class="border border-gray-300 px-2 py-2 text-left">{{ $rowLabel ?? 'Row' }}</th>
                             <th class="border border-gray-300 px-2 py-2 text-left">Country</th>
                             <th class="border border-gray-300 px-2 py-2 text-left">Name</th>
                             <th class="border border-gray-300 px-2 py-2 text-left">Email</th>

--- a/tests/Unit/BulkUserChanges/BulkUserChangesTextParserTest.php
+++ b/tests/Unit/BulkUserChanges/BulkUserChangesTextParserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\BulkUserChanges;
+
+use App\Services\BulkUserChanges\BulkUserChangesTextParser;
+use Tests\TestCase;
+
+final class BulkUserChangesTextParserTest extends TestCase
+{
+    private const SAMPLE_PASTE = <<<'TEXT'
+Poland
+Anita Kocunik
+anitakocunik@wp.pl
+add
+leading teachers
+Finland
+Anu Kahri
+anu.kahri@opetus.espoo.fi
+email change
+new email: anu.kahri@gmail.com
+Ireland
+Rory Leonard
+rory_leonard@yahoo.ie
+add
+ambassadors
+Ireland
+Veronica Ward
+vward@eircom.net
+delete
+ambassadors
+Sweden
+Joanna Lasek
+joanna.lasek@malmo.se
+add
+leading teachers
+TEXT;
+
+    public function test_parses_pasted_change_blocks(): void
+    {
+        $parsed = app(BulkUserChangesTextParser::class)->parse(self::SAMPLE_PASTE);
+
+        $this->assertSame('paste', $parsed['source']);
+        $this->assertSame(5, $parsed['meta']['parsed_rows']);
+        $this->assertSame('anitakocunik@wp.pl', $parsed['meta']['first_email']);
+        $this->assertSame('joanna.lasek@malmo.se', $parsed['meta']['last_email']);
+
+        $anita = $parsed['rows'][0];
+        $this->assertSame('role_add', $anita['operation']);
+        $this->assertSame('leading teacher', $anita['role_name']);
+
+        $anu = $parsed['rows'][1];
+        $this->assertSame('email_update', $anu['operation']);
+        $this->assertSame('anu.kahri@gmail.com', $anu['new_email']);
+
+        $rory = $parsed['rows'][2];
+        $this->assertSame('role_add', $rory['operation']);
+        $this->assertSame('ambassador', $rory['role_name']);
+
+        $veronica = $parsed['rows'][3];
+        $this->assertSame('role_remove', $veronica['operation']);
+        $this->assertSame('ambassador', $veronica['role_name']);
+    }
+
+    public function test_rejects_incomplete_paste(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('groups of 5 lines');
+
+        app(BulkUserChangesTextParser::class)->parse("Poland\nAnita\nanita@example.com\nadd\n");
+    }
+}


### PR DESCRIPTION
Super admins can paste five-line change blocks (country, name, email, action, role or new email) instead of uploading Excel. Uses the same preview and apply flow as the Changes sheet upload.