### PR TITLE
Process large bulk event uploads in background

### DIFF
--- a/app/Http/Controllers/BulkEventUploadController.php
+++ b/app/Http/Controllers/BulkEventUploadController.php
@@ -2,58 +2,34 @@
 
 namespace App\Http\Controllers;
 
-use App\Imports\GenericEventsImport;
-use App\Services\BulkEventImportResult;
+use App\Jobs\ProcessBulkEventImportJob;
+use App\Jobs\ValidateBulkEventUploadJob;
+use App\Services\BulkEventUploadCache;
 use App\Services\BulkEventUploadValidator;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
-use Maatwebsite\Excel\Facades\Excel;
 
 class BulkEventUploadController extends Controller
 {
-    private const SESSION_FILE_PATH = 'bulk_upload_file_path';
-    private const SESSION_DEFAULT_CREATOR = 'bulk_upload_default_creator_email';
-    private const SESSION_VALIDATION_PASSED = 'bulk_upload_validation_passed';
-    private const SESSION_VALIDATION_MISSING = 'bulk_upload_validation_missing';
-
-    /**
+  /**
      * Show the bulk upload form.
      */
     public function index(Request $request): View
     {
-        $validationMissing = $request->session()->get('validation_missing')
-            ?? $request->session()->get(self::SESSION_VALIDATION_MISSING, []);
-        $validationPassed = $request->session()->get(self::SESSION_VALIDATION_PASSED, false);
-        $filePath = $request->session()->get(self::SESSION_FILE_PATH);
-        $tempDisk = config('filesystems.bulk_upload_temp_disk', 'local');
-        $importPayload = $request->session()->get('bulk_upload_import_payload');
-        if ($importPayload === null || $importPayload === '') {
-            if ($validationPassed && $filePath) {
-                $importPayload = Crypt::encryptString(json_encode([
-                    'path' => $filePath,
-                    'default_creator_email' => $request->session()->get(self::SESSION_DEFAULT_CREATOR),
-                    'disk' => $tempDisk,
-                ]));
-            } else {
-                $importPayload = '';
-            }
-        }
-
         return view('admin.bulk-upload.index', [
-            'validationPassed' => $validationPassed,
-            'validationMissing' => $validationMissing,
-            'storedDefaultCreatorEmail' => $request->session()->get(self::SESSION_DEFAULT_CREATOR),
-            'import_payload' => $importPayload,
+            'validationPassed' => false,
+            'validationMissing' => $request->session()->get('validation_missing', []),
+            'storedDefaultCreatorEmail' => old('default_creator_email'),
+            'import_payload' => '',
         ]);
     }
 
     /**
-     * Upload file and validate required columns. Store file in session for import step.
+     * Upload file, queue validation, redirect to processing page.
      */
     public function validateUpload(Request $request): RedirectResponse
     {
@@ -100,12 +76,6 @@ class BulkEventUploadController extends Controller
         }
 
         $tempDisk = config('filesystems.bulk_upload_temp_disk', 'local');
-        $oldPath = $request->session()->get(self::SESSION_FILE_PATH);
-        if ($oldPath && Storage::disk($tempDisk)->exists($oldPath)) {
-            Storage::disk($tempDisk)->delete($oldPath);
-        }
-        $request->session()->forget([self::SESSION_FILE_PATH, self::SESSION_VALIDATION_PASSED, self::SESSION_VALIDATION_MISSING, self::SESSION_DEFAULT_CREATOR]);
-
         $path = $file->storeAs('temp', 'bulk_events_'.time().'.'.$extension, $tempDisk);
 
         $headerCheck = BulkEventUploadValidator::validateRequiredColumns($path, $tempDisk);
@@ -125,215 +95,135 @@ class BulkEventUploadController extends Controller
                 ->withInput();
         }
 
-        $request->session()->put(self::SESSION_FILE_PATH, $path);
-        $request->session()->put(self::SESSION_DEFAULT_CREATOR, $validated['default_creator_email'] ?? null);
-        $request->session()->put(self::SESSION_VALIDATION_PASSED, true);
-        $request->session()->forget(self::SESSION_VALIDATION_MISSING);
-
-        $defaultCreatorEmail = $validated['default_creator_email'] ?? null;
-
-        $result = new BulkEventImportResult;
-        $import = new GenericEventsImport($defaultCreatorEmail, $result, true);
-        Excel::import($import, $path, $tempDisk);
-
-        $rowStatuses = [];
-        foreach ($result->valid as $row => $_) {
-            $rowStatuses[$row] = ['row' => $row, 'valid' => true];
-        }
-        foreach ($result->failures as $row => $reason) {
-            $rowStatuses[$row] = ['row' => $row, 'valid' => false, 'message' => $reason];
-        }
-
-        $dataRowCount = BulkEventUploadValidator::getDataRowCount($path, $tempDisk);
-        $firstDataRow = 2;
-        for ($r = $firstDataRow; $r < $firstDataRow + $dataRowCount; $r++) {
-            if (! isset($rowStatuses[$r])) {
-                $rowStatuses[$r] = [
-                    'row' => $r,
-                    'valid' => false,
-                    'message' => 'Row was not validated (empty row or reader skipped).',
-                ];
-            }
-        }
-        ksort($rowStatuses);
-
-        $importToken = Str::random(64);
-        Cache::put('bulk_import_' . $importToken, [
+        $token = Str::random(64);
+        BulkEventUploadCache::put($token, [
+            'phase' => BulkEventUploadCache::PHASE_VALIDATING,
             'path' => $path,
             'disk' => $tempDisk,
-            'default_creator_email' => $defaultCreatorEmail,
-        ], now()->addHours(1));
+            'default_creator_email' => $validated['default_creator_email'] ?? null,
+            'error' => null,
+        ]);
 
-        $request->session()->put('bulk_upload_import_token', $importToken);
-        $request->session()->put('bulk_upload_import_payload', Crypt::encryptString(json_encode([
-            'path' => $path,
-            'default_creator_email' => $defaultCreatorEmail,
-            'disk' => $tempDisk,
-        ])));
+        ValidateBulkEventUploadJob::dispatch($token)->afterResponse();
 
-        return redirect()->route('admin.bulk-upload.preview')
-            ->with('bulk_upload_import_token', $importToken)
-            ->with('bulk_upload_row_statuses', array_values($rowStatuses));
+        return redirect()->route('admin.bulk-upload.processing', ['token' => $token]);
     }
 
-    /**
-     * Show validation preview: row-by-row green/red status. Payload from flash or session.
-     */
-    public function preview(Request $request): View|RedirectResponse
+    public function processing(string $token): View|RedirectResponse
     {
-        $importToken = $request->session()->get('bulk_upload_import_token');
-        $rowStatuses = $request->session()->get('bulk_upload_row_statuses', []);
-
-        if (empty($importToken)) {
-            $importPayload = $request->session()->get('bulk_upload_import_payload');
-            if ($importPayload === null || $importPayload === '') {
-                $filePath = $request->session()->get(self::SESSION_FILE_PATH);
-                $tempDisk = config('filesystems.bulk_upload_temp_disk', 'local');
-                if ($filePath) {
-                    $importPayload = Crypt::encryptString(json_encode([
-                        'path' => $filePath,
-                        'default_creator_email' => $request->session()->get(self::SESSION_DEFAULT_CREATOR),
-                        'disk' => $tempDisk,
-                    ]));
-                    $request->session()->put('bulk_upload_import_payload', $importPayload);
-                }
-            }
-            if ($importPayload === null || $importPayload === '') {
-                return redirect()->route('admin.bulk-upload.index')
-                    ->withErrors(['import' => 'No validated file found. Please upload and validate a file first.']);
-            }
-            return view('admin.bulk-upload.preview', [
-                'import_token' => '',
-                'import_payload' => $importPayload,
-                'row_statuses' => $rowStatuses,
-            ]);
+        $payload = BulkEventUploadCache::get($token);
+        if ($payload === null) {
+            return redirect()->route('admin.bulk-upload.index')
+                ->withErrors(['file' => 'Upload session expired. Please upload again.']);
         }
+
+        return view('admin.bulk-upload.processing', [
+            'token' => $token,
+            'phase' => $payload['phase'] ?? BulkEventUploadCache::PHASE_VALIDATING,
+        ]);
+    }
+
+    public function status(string $token): JsonResponse
+    {
+        $payload = BulkEventUploadCache::get($token);
+        if ($payload === null) {
+            return response()->json(['phase' => 'missing'], 404);
+        }
+
+        return response()->json([
+            'phase' => $payload['phase'] ?? BulkEventUploadCache::PHASE_VALIDATING,
+            'error' => $payload['error'] ?? null,
+            'preview_url' => route('admin.bulk-upload.preview', ['token' => $token]),
+            'report_url' => route('admin.bulk-upload.report', ['token' => $token]),
+        ]);
+    }
+
+  /**
+     * Show validation preview from cache.
+     */
+    public function preview(Request $request, ?string $token = null): View|RedirectResponse
+    {
+        $token = $token ?? (string) $request->query('token', '');
+        if ($token === '') {
+            return redirect()->route('admin.bulk-upload.index')
+                ->withErrors(['import' => 'No validated file found. Please upload and validate a file first.']);
+        }
+
+        $payload = BulkEventUploadCache::get($token);
+        if ($payload === null || ($payload['phase'] ?? '') !== BulkEventUploadCache::PHASE_VALIDATED) {
+            return redirect()->route('admin.bulk-upload.processing', ['token' => $token]);
+        }
+
+        $preview = $payload['preview'] ?? [];
 
         return view('admin.bulk-upload.preview', [
-            'import_token' => $importToken,
-            'import_payload' => '',
-            'row_statuses' => $rowStatuses,
+            'import_token' => $token,
+            'row_statuses' => $preview['row_statuses'] ?? [],
+            'valid_count' => $preview['valid_count'] ?? 0,
+            'total_count' => $preview['total_count'] ?? 0,
+            'failures_only' => $preview['failures_only'] ?? false,
         ]);
     }
 
     /**
-     * Run the import using file path from encrypted form payload or session.
-     * Payload avoids "No validated file found" when session is not shared (e.g. load balancer).
+     * Queue import and redirect to processing page.
      */
-    public function import(Request $request): View|RedirectResponse
+    public function import(Request $request): RedirectResponse
     {
-        $path = null;
-        $defaultCreatorEmail = null;
-        $tempDisk = config('filesystems.bulk_upload_temp_disk', 'local');
-
-        $token = $request->input('import_token');
-        if (is_string($token) && $token !== '') {
-            $cached = Cache::get('bulk_import_' . $token);
-            if (is_array($cached) && ! empty($cached['path'])) {
-                $path = $cached['path'];
-                $tempDisk = $cached['disk'] ?? $tempDisk;
-                $defaultCreatorEmail = $cached['default_creator_email'] ?? null;
-            }
-        }
-
-        if (! $path) {
-            $payload = $request->input('import_payload');
-            if (empty($payload) || ! is_string($payload)) {
-                $payload = $request->session()->get('bulk_upload_import_payload');
-            }
-            if (is_string($payload) && $payload !== '') {
-                try {
-                    $decoded = json_decode(Crypt::decryptString($payload), true);
-                    if (is_array($decoded) && ! empty($decoded['path'])) {
-                        $path = $decoded['path'];
-                        $defaultCreatorEmail = $decoded['default_creator_email'] ?? null;
-                        if (! empty($decoded['disk'])) {
-                            $tempDisk = $decoded['disk'];
-                        }
-                    }
-                } catch (\Throwable $e) {
-                    // Fall back to session path
-                }
-            }
-        }
-        if (! $path) {
-            $path = $request->session()->get(self::SESSION_FILE_PATH);
-            $defaultCreatorEmail = $request->session()->get(self::SESSION_DEFAULT_CREATOR);
-        }
-
-        if (! $path || ! Storage::disk($tempDisk)->exists($path)) {
-            $request->session()->forget([self::SESSION_FILE_PATH, self::SESSION_DEFAULT_CREATOR, self::SESSION_VALIDATION_PASSED, self::SESSION_VALIDATION_MISSING, 'bulk_upload_import_payload', 'bulk_upload_import_token', 'bulk_upload_row_statuses']);
-            if (is_string($token ?? null) && $token !== '') {
-                Cache::forget('bulk_import_' . $token);
-            }
-
-            $message = 'No validated file found. Please upload and validate a file first.';
-            if ($path && ! Storage::disk($tempDisk)->exists($path)) {
-                $message .= ' If you use multiple servers, set BULK_UPLOAD_TEMP_DISK=s3 in .env so the file is stored in shared storage.';
-            }
-
+        $token = (string) $request->input('import_token', '');
+        if ($token === '') {
             return redirect()->route('admin.bulk-upload.index')
-                ->withErrors(['import' => $message]);
+                ->withErrors(['import' => 'No validated file found. Please upload and validate a file first.']);
         }
 
-        try {
-            $result = new BulkEventImportResult;
-            $import = new GenericEventsImport($defaultCreatorEmail, $result);
-            Excel::import($import, $path, $tempDisk);
-
-            Storage::disk($tempDisk)->delete($path);
-            $request->session()->forget([self::SESSION_FILE_PATH, self::SESSION_DEFAULT_CREATOR, self::SESSION_VALIDATION_PASSED, self::SESSION_VALIDATION_MISSING, 'bulk_upload_import_payload', 'bulk_upload_import_token', 'bulk_upload_row_statuses']);
-            $token = $request->input('import_token');
-            if (is_string($token) && $token !== '') {
-                Cache::forget('bulk_import_' . $token);
-            }
-
-            $this->clearMapCache();
-
-            $request->session()->flash('bulk_upload_report_created', $result->created);
-            $request->session()->flash('bulk_upload_report_failures', $result->failures);
-
-            return redirect()->route('admin.bulk-upload.report');
-        } catch (\Throwable $e) {
-            if (Storage::disk($tempDisk)->exists($path)) {
-                Storage::disk($tempDisk)->delete($path);
-            }
-            $request->session()->forget([self::SESSION_FILE_PATH, self::SESSION_DEFAULT_CREATOR, self::SESSION_VALIDATION_PASSED, self::SESSION_VALIDATION_MISSING, 'bulk_upload_import_payload', 'bulk_upload_import_token', 'bulk_upload_row_statuses']);
-            $token = $request->input('import_token');
-            if (is_string($token) && $token !== '') {
-                Cache::forget('bulk_import_' . $token);
-            }
-
+        $payload = BulkEventUploadCache::get($token);
+        if ($payload === null || ($payload['phase'] ?? '') !== BulkEventUploadCache::PHASE_VALIDATED) {
             return redirect()->route('admin.bulk-upload.index')
-                ->withErrors(['import' => 'Import failed: '.$e->getMessage()]);
+                ->withErrors(['import' => 'Upload session expired or validation not finished. Please upload again.']);
         }
-    }
 
-    /**
-     * Show the import report (GET). Data is flashed from import() redirect.
-     * Refreshing this page will redirect back to index as flash data is gone.
-     */
-    public function report(Request $request): View|RedirectResponse
-    {
-        $created = $request->session()->get('bulk_upload_report_created');
-        $failures = $request->session()->get('bulk_upload_report_failures');
-
-        if ($created === null && $failures === null) {
+        $path = (string) ($payload['path'] ?? '');
+        $disk = (string) ($payload['disk'] ?? 'local');
+        if ($path === '' || ! Storage::disk($disk)->exists($path)) {
             return redirect()->route('admin.bulk-upload.index')
-                ->with('info', 'Report no longer available. Run an import to see a new report.');
+                ->withErrors(['import' => 'Uploaded file no longer available. Please upload again.']);
         }
 
-        return view('admin.bulk-upload.report', [
-            'created' => $created ?? [],
-            'failures' => $failures ?? [],
+        BulkEventUploadCache::merge($token, [
+            'phase' => BulkEventUploadCache::PHASE_IMPORTING,
+            'error' => null,
         ]);
+
+        ProcessBulkEventImportJob::dispatch($token)->afterResponse();
+
+        return redirect()->route('admin.bulk-upload.processing', ['token' => $token]);
     }
 
     /**
-     * Clear map cache so new/updated events appear on the map immediately.
+     * Show the import report from cache.
      */
-    private function clearMapCache(): void
+    public function report(Request $request, ?string $token = null): View|RedirectResponse
     {
-        Cache::flush();
+        $token = $token ?? (string) $request->query('token', '');
+        if ($token !== '') {
+            $payload = BulkEventUploadCache::get($token);
+            if ($payload !== null && ($payload['phase'] ?? '') === BulkEventUploadCache::PHASE_COMPLETED) {
+                $report = $payload['report'] ?? [];
+
+                return view('admin.bulk-upload.report', [
+                    'created' => $report['created'] ?? [],
+                    'created_count' => $report['created_count'] ?? count($report['created'] ?? []),
+                    'created_details_truncated' => $report['created_details_truncated'] ?? false,
+                    'failures' => $report['failures'] ?? [],
+                ]);
+            }
+
+            if ($payload !== null && ($payload['phase'] ?? '') !== BulkEventUploadCache::PHASE_COMPLETED) {
+                return redirect()->route('admin.bulk-upload.processing', ['token' => $token]);
+            }
+        }
+
+        return redirect()->route('admin.bulk-upload.index')
+            ->with('info', 'Report no longer available. Run an import to see a new report.');
     }
 }

--- a/app/Http/Controllers/BulkEventUploadController.php
+++ b/app/Http/Controllers/BulkEventUploadController.php
@@ -37,7 +37,7 @@ class BulkEventUploadController extends Controller
             'file' => [
                 'required',
                 'file',
-                'max:10240',
+                'max:51200',
                 function ($attribute, $value, $fail) {
                     if ($value) {
                         $ext = strtolower($value->getClientOriginalExtension());
@@ -54,7 +54,7 @@ class BulkEventUploadController extends Controller
             'default_creator_email' => ['nullable', 'email', 'max:255'],
         ], [
             'file.required' => 'Please select a file to upload.',
-            'file.max' => 'The file may not be greater than 10 MB.',
+            'file.max' => 'The file may not be greater than 50 MB.',
         ]);
 
         $file = $request->file('file');

--- a/app/Imports/GenericEventsImport.php
+++ b/app/Imports/GenericEventsImport.php
@@ -27,6 +27,9 @@ class GenericEventsImport extends BaseEventsImport implements ToModel, WithCusto
     /** Current Excel row number (2 = first data row after header). */
     protected int $currentRow = 2;
 
+    /** @var array<string, int|null> */
+    private array $creatorIdByEmail = [];
+
     public function __construct(?string $defaultCreatorEmail = null, ?BulkEventImportResult $result = null, bool $previewMode = false)
     {
         $this->defaultCreatorEmail = $defaultCreatorEmail ? trim($defaultCreatorEmail) : null;
@@ -136,21 +139,28 @@ class GenericEventsImport extends BaseEventsImport implements ToModel, WithCusto
         if (! $contactEmail || ! filter_var($contactEmail, FILTER_VALIDATE_EMAIL)) {
             return null;
         }
+
+        if (array_key_exists($contactEmail, $this->creatorIdByEmail)) {
+            return $this->creatorIdByEmail[$contactEmail];
+        }
+
         $user = User::where('email', $contactEmail)->first();
         if ($user) {
-            return $user->id;
+            return $this->creatorIdByEmail[$contactEmail] = $user->id;
         }
         [$local] = explode('@', $contactEmail, 2);
         $user = User::where('email', 'like', "{$local}@%")->first();
         if ($user) {
-            return $user->id;
+            return $this->creatorIdByEmail[$contactEmail] = $user->id;
         }
         try {
             $user = UserHelper::createUser($contactEmail);
-            return $user->id;
+
+            return $this->creatorIdByEmail[$contactEmail] = $user->id;
         } catch (\Exception $e) {
             Log::warning('User creation failed for contact_email: '.$contactEmail, ['exception' => $e->getMessage()]);
-            return null;
+
+            return $this->creatorIdByEmail[$contactEmail] = null;
         }
     }
 
@@ -175,6 +185,10 @@ class GenericEventsImport extends BaseEventsImport implements ToModel, WithCusto
     {
         $rowIndex = $this->currentRow++;
 
+        if ($this->result) {
+            $this->result->rowsProcessed++;
+        }
+
         try {
             return $this->processRow($rowIndex, $row);
         } catch (\Throwable $e) {
@@ -193,7 +207,6 @@ class GenericEventsImport extends BaseEventsImport implements ToModel, WithCusto
     protected function processRow(int $rowIndex, array $row): ?Model
     {
         $row = $this->normalizeRow($row);
-        Log::info('Importing row:', $row);
 
         // 1) coordinate validation
         $coordError = $this->validateCoordinates($row);

--- a/app/Jobs/ProcessBulkEventImportJob.php
+++ b/app/Jobs/ProcessBulkEventImportJob.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Imports\GenericEventsImport;
+use App\Services\BulkEventImportResult;
+use App\Services\BulkEventUploadCache;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Maatwebsite\Excel\Facades\Excel;
+
+class ProcessBulkEventImportJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 3600;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public readonly string $token,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $payload = BulkEventUploadCache::get($this->token);
+        if ($payload === null) {
+            return;
+        }
+
+        $path = (string) ($payload['path'] ?? '');
+        $disk = (string) ($payload['disk'] ?? 'local');
+        $defaultCreatorEmail = $payload['default_creator_email'] ?? null;
+
+        if ($path === '' || ! Storage::disk($disk)->exists($path)) {
+            BulkEventUploadCache::merge($this->token, [
+                'phase' => BulkEventUploadCache::PHASE_FAILED,
+                'error' => 'Uploaded file is no longer available. Please upload again.',
+            ]);
+
+            return;
+        }
+
+        BulkEventUploadCache::merge($this->token, [
+            'phase' => BulkEventUploadCache::PHASE_IMPORTING,
+            'error' => null,
+        ]);
+
+        try {
+            $result = new BulkEventImportResult;
+            $preview = $payload['preview'] ?? [];
+            $totalRows = (int) ($preview['total_count'] ?? 0);
+            $result->trackCreatedDetails = $totalRows <= BulkEventUploadCache::PREVIEW_FAILURES_ONLY_THRESHOLD;
+
+            $import = new GenericEventsImport($defaultCreatorEmail, $result);
+            Excel::import($import, $path, $disk);
+
+            Storage::disk($disk)->delete($path);
+            Cache::flush();
+
+            BulkEventUploadCache::merge($this->token, [
+                'phase' => BulkEventUploadCache::PHASE_COMPLETED,
+                'path' => null,
+                'report' => [
+                    'created' => $result->created,
+                    'created_count' => $result->createdCount,
+                    'created_details_truncated' => ! $result->trackCreatedDetails,
+                    'failures' => $result->failures,
+                ],
+                'error' => null,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('Bulk event upload import failed: '.$e->getMessage(), [
+                'token' => $this->token,
+            ]);
+
+            if (Storage::disk($disk)->exists($path)) {
+                Storage::disk($disk)->delete($path);
+            }
+
+            BulkEventUploadCache::merge($this->token, [
+                'phase' => BulkEventUploadCache::PHASE_FAILED,
+                'error' => 'Import failed: '.$e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Jobs/ValidateBulkEventUploadJob.php
+++ b/app/Jobs/ValidateBulkEventUploadJob.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Imports\GenericEventsImport;
+use App\Services\BulkEventImportResult;
+use App\Services\BulkEventUploadCache;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Maatwebsite\Excel\Facades\Excel;
+
+class ValidateBulkEventUploadJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 1800;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public readonly string $token,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $payload = BulkEventUploadCache::get($this->token);
+        if ($payload === null) {
+            return;
+        }
+
+        $path = (string) ($payload['path'] ?? '');
+        $disk = (string) ($payload['disk'] ?? 'local');
+        $defaultCreatorEmail = $payload['default_creator_email'] ?? null;
+
+        if ($path === '' || ! Storage::disk($disk)->exists($path)) {
+            BulkEventUploadCache::merge($this->token, [
+                'phase' => BulkEventUploadCache::PHASE_FAILED,
+                'error' => 'Uploaded file is no longer available. Please upload again.',
+            ]);
+
+            return;
+        }
+
+        try {
+            $result = new BulkEventImportResult;
+            $import = new GenericEventsImport($defaultCreatorEmail, $result, true);
+            Excel::import($import, $path, $disk);
+
+            $preview = BulkEventUploadCache::previewFromResult($result);
+
+            BulkEventUploadCache::merge($this->token, [
+                'phase' => BulkEventUploadCache::PHASE_VALIDATED,
+                'error' => null,
+                'preview' => $preview,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('Bulk event upload validation failed: '.$e->getMessage(), [
+                'token' => $this->token,
+            ]);
+
+            BulkEventUploadCache::merge($this->token, [
+                'phase' => BulkEventUploadCache::PHASE_FAILED,
+                'error' => 'Validation failed: '.$e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Services/BulkEventImportResult.php
+++ b/app/Services/BulkEventImportResult.php
@@ -15,6 +15,12 @@ class BulkEventImportResult
     /** @var array<int, true> Row index (1-based) => valid (for preview) */
     public array $valid = [];
 
+    public int $rowsProcessed = 0;
+
+    public int $createdCount = 0;
+
+    public bool $trackCreatedDetails = true;
+
     public function addFailure(int $rowIndex, string $reason): void
     {
         $this->failures[$rowIndex] = $reason;
@@ -27,6 +33,12 @@ class BulkEventImportResult
 
     public function addCreated(Event $event): void
     {
+        $this->createdCount++;
+
+        if (! $this->trackCreatedDetails) {
+            return;
+        }
+
         $this->created[] = [
             'id' => $event->id,
             'title' => $event->title,

--- a/app/Services/BulkEventUploadCache.php
+++ b/app/Services/BulkEventUploadCache.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+
+final class BulkEventUploadCache
+{
+    public const PHASE_VALIDATING = 'validating';
+
+    public const PHASE_VALIDATED = 'validated';
+
+    public const PHASE_IMPORTING = 'importing';
+
+    public const PHASE_COMPLETED = 'completed';
+
+    public const PHASE_FAILED = 'failed';
+
+    /** Above this row count, preview shows failures only (not every green row). */
+    public const PREVIEW_FAILURES_ONLY_THRESHOLD = 500;
+
+    public static function key(string $token): string
+    {
+        return 'bulk_upload_'.$token;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function get(string $token): ?array
+    {
+        $payload = Cache::get(self::key($token));
+
+        return is_array($payload) ? $payload : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function put(string $token, array $data): void
+    {
+        Cache::put(self::key($token), $data, now()->addHours(2));
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function merge(string $token, array $data): void
+    {
+        self::put($token, array_merge(self::get($token) ?? [], $data));
+    }
+
+    /**
+     * @return array{
+     *   valid_count: int,
+     *   total_count: int,
+     *   failures_only: bool,
+     *   row_statuses: list<array{row: int, valid: bool, message?: string}>
+     * }
+     */
+    public static function previewFromResult(BulkEventImportResult $result): array
+    {
+        $validCount = count($result->valid);
+        $failureCount = count($result->failures);
+        $totalCount = max($result->rowsProcessed, $validCount + $failureCount);
+        $failuresOnly = $totalCount > self::PREVIEW_FAILURES_ONLY_THRESHOLD;
+
+        $rowStatuses = [];
+
+        if ($failuresOnly) {
+            foreach ($result->failures as $row => $message) {
+                $rowStatuses[] = [
+                    'row' => (int) $row,
+                    'valid' => false,
+                    'message' => $message,
+                ];
+            }
+        } else {
+            foreach ($result->valid as $row => $_) {
+                $rowStatuses[] = ['row' => (int) $row, 'valid' => true];
+            }
+            foreach ($result->failures as $row => $message) {
+                $rowStatuses[] = [
+                    'row' => (int) $row,
+                    'valid' => false,
+                    'message' => $message,
+                ];
+            }
+
+            usort($rowStatuses, fn (array $a, array $b) => $a['row'] <=> $b['row']);
+        }
+
+        return [
+            'valid_count' => $validCount,
+            'total_count' => $totalCount,
+            'failures_only' => $failuresOnly,
+            'row_statuses' => $rowStatuses,
+        ];
+    }
+}

--- a/resources/views/admin/bulk-upload/index.blade.php
+++ b/resources/views/admin/bulk-upload/index.blade.php
@@ -9,7 +9,7 @@
         </section>
 
         <section class="codeweek-content-wrapper">
-            <p class="mb-4">Upload an Excel or CSV file with event data. First click <strong>Upload &amp; validate</strong> to check that all required column headers are present. If validation passes, click <strong>Import</strong> to run the import. You can set an optional default creator email; otherwise events use the contact email (and a user will be created if needed).</p>
+            <p class="mb-4">Upload an Excel or CSV file with event data. Click <strong>Upload &amp; validate</strong> — large files are processed in the background so the upload does not time out. When validation finishes you will see a preview, then click <strong>Import</strong> to create events. You can set an optional default creator email; otherwise events use the contact email (and a user will be created if needed).</p>
 
             @if (session('success'))
                 <div class="mb-4 p-4 rounded bg-green-50 border border-green-200 text-green-800">
@@ -109,25 +109,6 @@
                         @endforeach
                     </ul>
                     <p class="text-sm text-amber-700 mt-2">Add the missing columns to your file and upload again.</p>
-                </div>
-            @endif
-
-            {{-- Step 2: Import (only when validation passed) --}}
-            @if ($validationPassed)
-                <div class="p-4 rounded bg-green-50 border border-green-200">
-                    <h2 class="text-lg font-semibold mb-2 text-green-800">Step 2: Import</h2>
-                    <p class="mb-3 text-green-700">All required columns are present. Click the button below to run the import.</p>
-                    <form method="POST" action="{{ route('admin.bulk-upload.import') }}" class="inline" id="bulk-upload-import-form">
-                        @csrf
-                        <input type="hidden" name="import_payload" value="{{ $import_payload ?? '' }}">
-                        <button type="submit" id="bulk-upload-import-btn" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-[#20262C] hover:bg-hover-orange duration-300">Import</button>
-                    </form>
-                    <script>
-                        document.getElementById('bulk-upload-import-form').addEventListener('submit', function () {
-                            var btn = document.getElementById('bulk-upload-import-btn');
-                            if (btn) { btn.disabled = true; btn.textContent = 'Importing…'; }
-                        });
-                    </script>
                 </div>
             @endif
         </section>

--- a/resources/views/admin/bulk-upload/index.blade.php
+++ b/resources/views/admin/bulk-upload/index.blade.php
@@ -57,7 +57,7 @@
                                 <span id="bulk-upload-file-name" class="text-sm text-gray-600 italic">No file chosen</span>
                                 <span id="bulk-upload-file-attached" class="hidden text-sm font-medium text-green-700 bg-green-100 px-2 py-0.5 rounded">Attached</span>
                             </div>
-                            <p class="text-sm text-gray-600 mt-1">Max 10 MB. Required columns: activity_title, name_of_organisation, type_of_organisation, activity_type, description, address, country, start_date, end_date, longitude, latitude, contact_email, organiser_website, participants_count, males_count, females_count, other_count.</p>
+                            <p class="text-sm text-gray-600 mt-1">Max 50 MB. Required columns: activity_title, name_of_organisation, type_of_organisation, activity_type, description, address, country, start_date, end_date, longitude, latitude, contact_email, organiser_website, participants_count, males_count, females_count, other_count.</p>
                         </div>
 
                         <div class="codeweek-form-button-container">

--- a/resources/views/admin/bulk-upload/preview.blade.php
+++ b/resources/views/admin/bulk-upload/preview.blade.php
@@ -9,10 +9,18 @@
 
         <section class="codeweek-content-wrapper">
             @php
-                $validCount = collect($row_statuses)->where('valid', true)->count();
-                $totalCount = count($row_statuses);
+                $validCount = $valid_count ?? collect($row_statuses)->where('valid', true)->count();
+                $totalCount = $total_count ?? count($row_statuses);
             @endphp
-            <p class="mb-2"><strong>{{ $validCount }} of {{ $totalCount }}</strong> rows passed validation. Rows below: <span class="bg-trans-success text-green-800 px-1 rounded">green</span> = valid, <span class="bg-trans-danger text-red-800 px-1 rounded">red</span> = problem (see Details). You can still run the import; invalid rows will be skipped. Click <strong>Import</strong> to run the import.</p>
+            <p class="mb-2">
+                <strong>{{ $validCount }} of {{ $totalCount }}</strong> rows passed validation.
+                @if ($failures_only ?? false)
+                    Only problem rows are listed below (file too large to show every valid row).
+                @else
+                    Rows below: <span class="bg-trans-success text-green-800 px-1 rounded">green</span> = valid, <span class="bg-trans-danger text-red-800 px-1 rounded">red</span> = problem.
+                @endif
+                You can still run the import; invalid rows will be skipped.
+            </p>
 
             @if ($errors->any())
                 <div class="mb-4 p-4 rounded bg-red-50 border border-red-200">
@@ -54,7 +62,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="3" class="border border-gray-300 px-3 py-4 text-gray-500 text-center">No data rows to show.</td>
+                                <td colspan="3" class="border border-gray-300 px-3 py-4 text-gray-500 text-center">No problem rows to show.</td>
                             </tr>
                         @endforelse
                     </tbody>
@@ -63,17 +71,13 @@
 
             <form method="POST" action="{{ route('admin.bulk-upload.import') }}" class="inline" id="bulk-upload-import-form">
                 @csrf
-                @if(!empty($import_token))
-                    <input type="hidden" name="import_token" value="{{ $import_token }}">
-                @else
-                    <input type="hidden" name="import_payload" value="{{ $import_payload ?? '' }}">
-                @endif
+                <input type="hidden" name="import_token" value="{{ $import_token }}">
                 <button type="submit" id="bulk-upload-import-btn" class="bg-primary cursor-pointer px-6 py-3 rounded-full font-semibold text-white hover:opacity-90 duration-300">Import</button>
             </form>
             <script>
                 document.getElementById('bulk-upload-import-form').addEventListener('submit', function () {
                     var btn = document.getElementById('bulk-upload-import-btn');
-                    if (btn) { btn.disabled = true; btn.textContent = 'Importing…'; }
+                    if (btn) { btn.disabled = true; btn.textContent = 'Starting import…'; }
                 });
             </script>
         </section>

--- a/resources/views/admin/bulk-upload/processing.blade.php
+++ b/resources/views/admin/bulk-upload/processing.blade.php
@@ -1,0 +1,84 @@
+@extends('layout.base')
+
+@section('content')
+    <section id="codeweek-bulk-upload-processing-page" class="codeweek-page">
+        <section class="codeweek-content-header">
+            <h1>Bulk Event Upload – processing</h1>
+        </section>
+
+        <section class="codeweek-content-wrapper">
+            <div id="bulk-upload-processing-panel" class="p-6 rounded bg-blue-50 border border-blue-200 max-w-xl">
+                <p id="bulk-upload-processing-message" class="text-lg font-medium mb-2">Working…</p>
+                <p id="bulk-upload-processing-detail" class="text-sm text-gray-700 mb-4">Large files are processed in the background so the browser does not time out. This page will update automatically.</p>
+                <p class="text-sm text-gray-500 animate-pulse">Please keep this tab open.</p>
+            </div>
+
+            <div id="bulk-upload-processing-error" class="hidden mt-4 p-4 rounded bg-red-50 border border-red-200 text-red-700"></div>
+        </section>
+    </section>
+
+    <script>
+        (function () {
+            var token = @json($token);
+            var initialPhase = @json($phase);
+            var messageEl = document.getElementById('bulk-upload-processing-message');
+            var errorEl = document.getElementById('bulk-upload-processing-error');
+            var statusUrl = @json(route('admin.bulk-upload.status', ['token' => $token]));
+
+            var phaseLabels = {
+                validating: 'Validating your file…',
+                validated: 'Validation complete. Opening preview…',
+                importing: 'Importing events…',
+                completed: 'Import complete. Opening report…',
+                failed: 'Something went wrong.'
+            };
+
+            function setMessage(phase) {
+                messageEl.textContent = phaseLabels[phase] || 'Working…';
+            }
+
+            setMessage(initialPhase);
+
+            function poll() {
+                fetch(statusUrl, { headers: { 'Accept': 'application/json' } })
+                    .then(function (response) { return response.json(); })
+                    .then(function (data) {
+                        if (!data || !data.phase) {
+                            return;
+                        }
+
+                        setMessage(data.phase);
+
+                        if (data.phase === 'validated' && data.preview_url) {
+                            window.location.href = data.preview_url;
+                            return;
+                        }
+
+                        if (data.phase === 'completed' && data.report_url) {
+                            window.location.href = data.report_url;
+                            return;
+                        }
+
+                        if (data.phase === 'failed') {
+                            errorEl.textContent = data.error || 'Processing failed.';
+                            errorEl.classList.remove('hidden');
+                            return;
+                        }
+
+                        setTimeout(poll, 2000);
+                    })
+                    .catch(function () {
+                        setTimeout(poll, 3000);
+                    });
+            }
+
+            if (initialPhase === 'validated') {
+                poll();
+            } else if (initialPhase === 'completed') {
+                poll();
+            } else if (initialPhase !== 'failed') {
+                setTimeout(poll, 1500);
+            }
+        })();
+    </script>
+@endsection

--- a/resources/views/admin/bulk-upload/report.blade.php
+++ b/resources/views/admin/bulk-upload/report.blade.php
@@ -8,16 +8,24 @@
         </section>
 
         <section class="codeweek-content-wrapper">
-            @if (count($created) > 0)
-                <h2 class="text-xl font-semibold mt-6 mb-2">Created events ({{ count($created) }})</h2>
-                <ul class="list-disc list-inside mb-6">
-                    @foreach ($created as $event)
-                        <li>
-                            <a href="{{ $event['url'] }}" target="_blank" rel="noopener" class="text-blue-600 hover:underline">{{ $event['title'] }}</a>
-                            <span class="text-gray-500">(ID: {{ $event['id'] }})</span>
-                        </li>
-                    @endforeach
-                </ul>
+            @php
+                $createdCount = $created_count ?? count($created);
+            @endphp
+
+            @if ($createdCount > 0)
+                <h2 class="text-xl font-semibold mt-6 mb-2">Created events ({{ $createdCount }})</h2>
+                @if ($created_details_truncated ?? false)
+                    <p class="text-sm text-gray-600 mb-4">Individual event links are omitted for large imports. Events were created successfully.</p>
+                @else
+                    <ul class="list-disc list-inside mb-6">
+                        @foreach ($created as $event)
+                            <li>
+                                <a href="{{ $event['url'] }}" target="_blank" rel="noopener" class="text-blue-600 hover:underline">{{ $event['title'] }}</a>
+                                <span class="text-gray-500">(ID: {{ $event['id'] }})</span>
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
             @endif
 
             @if (count($failures) > 0)
@@ -41,7 +49,7 @@
                 </table>
             @endif
 
-            @if (count($created) === 0 && count($failures) === 0)
+            @if ($createdCount === 0 && count($failures) === 0)
                 <p class="text-gray-600">No events were created and no failures were recorded. The file may have had no data rows.</p>
             @endif
         </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,8 @@ use Illuminate\Support\Facades\Config;
 Route::middleware(['auth', 'role:super admin'])->group(function () {
     Route::get('/admin/bulk-upload', [BulkEventUploadController::class, 'index'])->name('admin.bulk-upload.index');
     Route::post('/admin/bulk-upload/validate', [BulkEventUploadController::class, 'validateUpload'])->name('admin.bulk-upload.validate');
+    Route::get('/admin/bulk-upload/processing/{token}', [BulkEventUploadController::class, 'processing'])->name('admin.bulk-upload.processing');
+    Route::get('/admin/bulk-upload/status/{token}', [BulkEventUploadController::class, 'status'])->name('admin.bulk-upload.status');
     Route::get('/admin/bulk-upload/preview', [BulkEventUploadController::class, 'preview'])->name('admin.bulk-upload.preview');
     Route::post('/admin/bulk-upload/import', [BulkEventUploadController::class, 'import'])->name('admin.bulk-upload.import');
     Route::get('/admin/bulk-upload/import', fn () => redirect()->route('admin.bulk-upload.index'))->name('admin.bulk-upload.import.get');

--- a/tests/Unit/BulkEventUploadCacheTest.php
+++ b/tests/Unit/BulkEventUploadCacheTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\BulkEventImportResult;
+use App\Services\BulkEventUploadCache;
+use Tests\TestCase;
+
+final class BulkEventUploadCacheTest extends TestCase
+{
+    public function test_preview_from_result_uses_failures_only_for_large_uploads(): void
+    {
+        $result = new BulkEventImportResult;
+        $result->rowsProcessed = 600;
+
+        for ($row = 2; $row <= 601; $row++) {
+            if ($row === 42) {
+                continue;
+            }
+            $result->addValid($row);
+        }
+        $result->addFailure(42, 'Row 42 — bad date');
+
+        $preview = BulkEventUploadCache::previewFromResult($result);
+
+        $this->assertTrue($preview['failures_only']);
+        $this->assertSame(599, $preview['valid_count']);
+        $this->assertSame(600, $preview['total_count']);
+        $this->assertCount(1, $preview['row_statuses']);
+        $this->assertSame(42, $preview['row_statuses'][0]['row']);
+    }
+}


### PR DESCRIPTION
## Summary
- Moves bulk event **validation** and **import** into background queue jobs so uploads with thousands of rows no longer hit gateway timeouts.
- Adds a **processing** page with status polling, then redirects to preview or report when done.
- For uploads over 500 rows, preview shows **problem rows only**; report shows created **count** without listing every event link.
- Raises upload limit from 10 MB to **50 MB** for large Excel/CSV files.

## Test plan
- [ ] Confirm queue workers are running on prod (`--timeout=3600` recommended)
- [ ] Upload a ~3000–6000 row CSV at `/admin/bulk-upload` — should reach processing page quickly, then preview
- [ ] Run import — processing page → report with created count
- [ ] Verify file over 10 MB but under 50 MB is accepted
- [x] `php artisan test tests/Unit/BulkEventUploadCacheTest.php`

## Deploy notes
- Requires **queue workers** processing `ValidateBulkEventUploadJob` and `ProcessBulkEventImportJob`
- If multiple app servers: `BULK_UPLOAD_TEMP_DISK=s3`
- Server `upload_max_filesize` / `post_max_size` must allow 50 MB (Forge PHP settings)


Made with [Cursor](https://cursor.com)