### PR TITLE
Require matching address or coordinates for bulk upload duplicates.

### DIFF
--- a/app/Imports/GenericEventsImport.php
+++ b/app/Imports/GenericEventsImport.php
@@ -5,6 +5,7 @@ namespace App\Imports;
 use App\Event;
 use App\Helpers\UserHelper;
 use App\User;
+use App\Services\BulkEventDuplicateFinder;
 use App\Services\BulkEventImportResult;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
@@ -352,12 +353,8 @@ class GenericEventsImport extends BaseEventsImport implements ToModel, WithCusto
             return null;
         }
 
-        // 8) duplicate check: find existing by title + start_date + country_iso + organizer; if found, update instead of create
-        $existing = Event::where('title', $attrs['title'])
-            ->where('start_date', $attrs['start_date'])
-            ->where('country_iso', $attrs['country_iso'])
-            ->where('organizer', $attrs['organizer'])
-            ->first();
+        // 8) duplicate check: same title/date/country/organiser + same address or coordinates → update
+        $existing = app(BulkEventDuplicateFinder::class)->find($attrs);
 
         try {
             if ($existing) {

--- a/app/Services/BulkEventDuplicateFinder.php
+++ b/app/Services/BulkEventDuplicateFinder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Event;
+
+final class BulkEventDuplicateFinder
+{
+    private const COORDINATE_EPSILON = 0.00005;
+
+    /**
+     * Find an existing event that should be updated instead of creating a new row.
+     * Matches title, start date, country, organiser, and either address or coordinates.
+     *
+     * @param  array<string, mixed>  $attrs
+     */
+    public function find(array $attrs): ?Event
+    {
+        $query = Event::query()
+            ->where('title', $attrs['title'])
+            ->where('start_date', $attrs['start_date'])
+            ->where('country_iso', $attrs['country_iso'])
+            ->where('organizer', $attrs['organizer']);
+
+        $location = trim((string) ($attrs['location'] ?? ''));
+        $latitude = (float) ($attrs['latitude'] ?? 0);
+        $longitude = (float) ($attrs['longitude'] ?? 0);
+        $hasCoordinates = abs($latitude) > self::COORDINATE_EPSILON
+            || abs($longitude) > self::COORDINATE_EPSILON;
+
+        if ($location !== '') {
+            $query->where('location', $location);
+        } elseif ($hasCoordinates) {
+            $query->whereBetween('latitude', [$latitude - self::COORDINATE_EPSILON, $latitude + self::COORDINATE_EPSILON])
+                ->whereBetween('longitude', [$longitude - self::COORDINATE_EPSILON, $longitude + self::COORDINATE_EPSILON]);
+        }
+
+        return $query->first();
+    }
+}

--- a/tests/Unit/BulkEventDuplicateFinderTest.php
+++ b/tests/Unit/BulkEventDuplicateFinderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Event;
+use App\Services\BulkEventDuplicateFinder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class BulkEventDuplicateFinderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_does_not_match_when_only_address_differs(): void
+    {
+        Event::factory()->create([
+            'title' => 'Coding workshop',
+            'organizer' => 'Example School',
+            'location' => '1 Main Street',
+            'country_iso' => 'IE',
+            'start_date' => '2026-10-10 09:00:00',
+            'end_date' => '2026-10-10 12:00:00',
+            'latitude' => 53.3,
+            'longitude' => -6.2,
+        ]);
+
+        $match = app(BulkEventDuplicateFinder::class)->find([
+            'title' => 'Coding workshop',
+            'start_date' => '2026-10-10 09:00:00',
+            'country_iso' => 'IE',
+            'organizer' => 'Example School',
+            'location' => '2 Other Road',
+            'latitude' => 53.31,
+            'longitude' => -6.21,
+        ]);
+
+        $this->assertNull($match);
+    }
+
+    public function test_matches_when_core_fields_and_address_are_the_same(): void
+    {
+        $event = Event::factory()->create([
+            'title' => 'Coding workshop',
+            'organizer' => 'Example School',
+            'location' => '1 Main Street',
+            'country_iso' => 'IE',
+            'start_date' => '2026-10-10 09:00:00',
+            'end_date' => '2026-10-10 12:00:00',
+            'latitude' => 53.3,
+            'longitude' => -6.2,
+        ]);
+
+        $match = app(BulkEventDuplicateFinder::class)->find([
+            'title' => 'Coding workshop',
+            'start_date' => '2026-10-10 09:00:00',
+            'country_iso' => 'IE',
+            'organizer' => 'Example School',
+            'location' => '1 Main Street',
+            'latitude' => 53.30001,
+            'longitude' => -6.20001,
+        ]);
+
+        $this->assertNotNull($match);
+        $this->assertSame($event->id, $match->id);
+    }
+
+    public function test_does_not_match_when_coordinates_differ_and_address_is_empty(): void
+    {
+        Event::factory()->create([
+            'title' => 'Robotics day',
+            'organizer' => 'STEM Hub',
+            'location' => '',
+            'country_iso' => 'DE',
+            'start_date' => '2026-11-01 10:00:00',
+            'end_date' => '2026-11-01 14:00:00',
+            'latitude' => 52.52,
+            'longitude' => 13.405,
+        ]);
+
+        $match = app(BulkEventDuplicateFinder::class)->find([
+            'title' => 'Robotics day',
+            'start_date' => '2026-11-01 10:00:00',
+            'country_iso' => 'DE',
+            'organizer' => 'STEM Hub',
+            'location' => '',
+            'latitude' => 48.13,
+            'longitude' => 11.58,
+        ]);
+
+        $this->assertNull($match);
+    }
+}


### PR DESCRIPTION
Prevents distinct events with the same title, date, country, and organiser from being merged when they differ by location.