### PR TITLE
Cap password length at 72 characters (DoS hardening)

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -42,6 +43,14 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    protected function validateLogin(Request $request): void
+    {
+        $request->validate([
+            $this->username() => 'required|string',
+            'password' => 'required|string|max:72',
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -50,7 +50,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
-            'password' => Password::defaults(),
+            'password' => ['required', 'string', Password::defaults()],
             'privacy' => 'required',
         ]);
     }

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Illuminate\Validation\Rules\Password;
 
 class ResetPasswordController extends Controller
 {
@@ -35,5 +36,17 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function rules(): array
+    {
+        return [
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => ['required', 'string', 'confirmed', Password::defaults()],
+        ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,6 +39,7 @@ class AppServiceProvider extends ServiceProvider
                 ->mixedCase()
                 ->numbers()
                 ->symbols()
+                ->max(72)
                 ->uncompromised();
         });
 

--- a/resources/js/components/PasswordField.vue
+++ b/resources/js/components/PasswordField.vue
@@ -8,6 +8,7 @@
       :type="type"
       :defaultValue="value"
       :required="required"
+      maxlength="72"
     />
     <div
       class="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer"

--- a/tests/Feature/Auth/PasswordLengthValidationTest.php
+++ b/tests/Feature/Auth/PasswordLengthValidationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class PasswordLengthValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_rejects_password_longer_than_72_characters(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'long-password@example.com',
+            'password' => Str::repeat('Aa1!', 19), // 76 chars
+            'password_confirmation' => Str::repeat('Aa1!', 19),
+            'privacy' => '1',
+        ]);
+
+        $response->assertSessionHasErrors('password');
+        $this->assertDatabaseMissing('users', ['email' => 'long-password@example.com']);
+    }
+
+    public function test_login_rejects_password_longer_than_72_characters(): void
+    {
+        $response = $this->post('/login', [
+            'email' => 'user@example.com',
+            'password' => Str::repeat('x', 73),
+        ]);
+
+        $response->assertSessionHasErrors('password');
+    }
+
+    public function test_registration_page_renders_password_fields(): void
+    {
+        $response = $this->get('/register');
+
+        $response->assertOk();
+        $response->assertSee('name="password"', false);
+        $response->assertSee('name="password_confirmation"', false);
+    }
+
+    public function test_registration_accepts_password_at_max_length(): void
+    {
+        $password = Str::repeat('Aa1!', 18); // 72 chars, meets complexity rules
+        $this->assertSame(72, strlen($password));
+
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'max-length@example.com',
+            'password' => $password,
+            'password_confirmation' => $password,
+            'privacy' => '1',
+        ]);
+
+        $response->assertSessionDoesntHaveErrors(['password']);
+    }
+}


### PR DESCRIPTION
## Summary
- Enforce a 72-character maximum password length server-side on registration, login, and password reset
- Add `maxlength="72"` on the shared password field component
- Add tests confirming oversized passwords are rejected and valid 72-character passwords still pass validation

## Test plan
- [x] `php artisan test tests/Feature/Auth/PasswordLengthValidationTest.php`
- [ ] After deploy: register with a normal password on https://codeweek.eu/register
- [ ] After deploy: confirm an oversized password returns a validation error
- [ ] Run `npm run build` on Forge so the frontend maxlength is live


Made with [Cursor](https://cursor.com)