### PR TITLE
Always show Discover Digital Key one-pagers note per locale.

### DIFF
--- a/app/Nova/TrainingResource.php
+++ b/app/Nova/TrainingResource.php
@@ -70,7 +70,7 @@ class TrainingResource extends Resource
             )
                 ->nullable()
                 ->hideFromIndex()
-                ->help('Leave empty to keep the default English PDF links. Use the toolbar to add links (select text → link), lists, and headings. Include [[key_one_pagers_locale_note]] if you want the translated intro sentence.')
+                ->help('Leave empty to keep the default English PDF links. Use the toolbar to add links (select text → link), lists, and headings. For Discover Digital, the Key one-pagers intro sentence is added automatically in the visitor’s language.')
                 ->resolveUsing(function () use ($locale) {
                     $overrides = $this->resource->locale_overrides ?? [];
 

--- a/app/TrainingResource.php
+++ b/app/TrainingResource.php
@@ -216,4 +216,44 @@ class TrainingResource extends Model
 
         return is_array($replacements) && $replacements !== [];
     }
+
+    /**
+     * PDF links HTML with the locale-aware Key one-pagers note applied.
+     */
+    public function renderedPdfLinksSectionForLocale(?string $locale = null): string
+    {
+        $section = $this->pdfLinksSectionForLocale($locale);
+        if ($section === '') {
+            return '';
+        }
+
+        $noteHtml = '<span class="block mb-4">'.e(__('training.discover_digital_key_one_pagers_note')).'</span>';
+
+        if (str_contains($section, '[[key_one_pagers_locale_note]]')) {
+            return str_replace('[[key_one_pagers_locale_note]]', $noteHtml, $section);
+        }
+
+        // Discover Digital: inject the note even when locale overrides omit the placeholder.
+        if ($this->slug !== 'discover-digital-programme') {
+            return $section;
+        }
+
+        $headingPatterns = [
+            '/(<h2[^>]*\bid=(["\'])key-one-pagers\2[^>]*>.*?<\/h2>)/is',
+            '/(<h2[^>]*>\s*Key one-pagers\s*<\/h2>)/is',
+            '/((?:<div[^>]*>\s*)?<strong>\s*Key one-pagers\s*<\/strong>(?:\s*<\/div>)?)/is',
+        ];
+
+        foreach ($headingPatterns as $pattern) {
+            if (preg_match($pattern, $section) === 1) {
+                return preg_replace($pattern, '$1'.$noteHtml, $section, 1) ?? $section;
+            }
+        }
+
+        if (! str_contains(mb_strtolower($section), 'key one-pagers')) {
+            return '<h2 id="key-one-pagers">Key one-pagers</h2>'.$noteHtml.$section;
+        }
+
+        return $noteHtml.$section;
+    }
 }

--- a/resources/views/training/show.blade.php
+++ b/resources/views/training/show.blade.php
@@ -132,14 +132,7 @@
 
                 @if(!empty($trainingResource->pdf_links_section) || $trainingResource->hasPdfLinksOverrideForLocale())
                     @php
-                        $pdfLinksSection = $trainingResource->pdfLinksSectionForLocale();
-                        if (str_contains($pdfLinksSection, '[[key_one_pagers_locale_note]]')) {
-                            $pdfLinksSection = str_replace(
-                                '[[key_one_pagers_locale_note]]',
-                                '<span class="block mb-4">'.e(__('training.discover_digital_key_one_pagers_note')).'</span>',
-                                $pdfLinksSection
-                            );
-                        }
+                        $pdfLinksSection = $trainingResource->renderedPdfLinksSectionForLocale();
                     @endphp
                     @if($pdfLinksSection !== '')
                         <div class="{{ $pdfClass }}">


### PR DESCRIPTION
Romanian PDF overrides often omit the placeholder, so inject the translated intro automatically after the heading (or restore the heading when missing).